### PR TITLE
[Bug Fix] Fix the issue mfgtool cannot recognize HID device of a composite device

### DIFF
--- a/Apps/MfgToolLib/Device.cpp
+++ b/Apps/MfgToolLib/Device.cpp
@@ -80,6 +80,7 @@ Device::Device(DeviceClass *deviceClass, DEVINST devInst, CString path, INSTANCE
     _deviceInstanceID.describe(this, _T("Device Instance Id"), _T(""));
     _enumerator.describe(this, _T("Enumerator"), _T(""));
     _classStr.describe(this, _T("Class"), _T(""));
+    _compatibleIds.describe(this, _T("Compatible Ids"), _T(""));
     _classDesc.describe(this, _T("Class Description"), _T(""));
     _classGuid.describe(this, _T("Device Class GUID"), _T("Describes the device class."));
     _hub.describe(this, _T("USB Hub Path"), _T("Path of Hub USB Device is connected to."));
@@ -231,7 +232,23 @@ Device* Device::UsbDevice()
         return NULL;
 
     if (_enumerator.get().CompareNoCase(_T("USB")) == 0)
-        return this;
+    {
+        // if current node is hub device, then return this node.
+        if ((_compatibleIds.get().MakeUpper().Find(_T("CLASS_09")) >= 0) || (_description.get().MakeUpper().Find(_T("HUB")) >= 0))
+        {
+            return this;
+        }
+        // Check if it's parent is an usb hub.
+        // If yes, this node is the correct usb device.
+        if ((Parent()->_compatibleIds.get().MakeUpper().Find(_T("CLASS_09")) >= 0) || (Parent()->_description.get().MakeUpper().Find(_T("HUB")) >= 0))
+        {
+            return this;
+        }
+        else // If not, this node is not the correct usb device, but a child of the usb device.
+        {
+            return Parent()->UsbDevice();
+        }
+    }
 
     return Parent()->UsbDevice();
 }
@@ -462,6 +479,22 @@ CString Device::classStr::get()
 }
 
 /// <summary>
+/// Property: Gets the device's compatible IDs.
+/// </summary>
+CString Device::compatibleIds::get()
+{
+	Device* dev = dynamic_cast<Device*>(_owner);
+	ASSERT(dev);
+
+	if (_value.IsEmpty())
+	{
+		_value = (dev->GetProperty(SPDRP_COMPATIBLEIDS, CString(_T(""))));
+	}
+
+	return _value;
+}
+
+/// <summary>
 /// Property: Gets the description for the device class.
 /// </summary>
 CString Device::classDesc::get()
@@ -498,7 +531,7 @@ CString Device::hub::get()
         if(dev->UsbDevice()->Parent() != NULL)
         {
 			//if(dev->UsbDevice()->Parent()->_enumerator.get().CompareNoCase(_T("USB")) == 0)
-			if(dev->UsbDevice()->Parent()->_classStr.get().CompareNoCase(_T("USB")) == 0)
+			if ((dev->UsbDevice()->Parent()->_compatibleIds.get().MakeUpper().Find(_T("CLASS_09")) >= 0) || (dev->UsbDevice()->Parent()->_description.get().MakeUpper().Find(_T("HUB")) >= 0))
             {
                 //_value = dev->UsbDevice()->Parent()->_path.get();
 				CString hubDriver = dev->UsbDevice()->Parent()->_driver.get();

--- a/Apps/MfgToolLib/Device.h
+++ b/Apps/MfgToolLib/Device.h
@@ -159,12 +159,18 @@ public:
 		CString get(); 
 	}_classStr;
 	
+	class compatibleIds : public StringProperty
+	{
+	public:
+		CString get();
+	}_compatibleIds;
+
 	class classDesc : public StringProperty 
 	{ 
 	public: 
 		CString get(); 
 	}_classDesc;
-	
+
 	class hub : public StringProperty 
 	{ 
 	public: 

--- a/Apps/MfgToolLib/MfgToolLib.cpp
+++ b/Apps/MfgToolLib/MfgToolLib.cpp
@@ -2347,7 +2347,12 @@ UINT COpCmd_Blhost::ExecuteCommand(int index)
 		}
 		peripheral = CString("-p ") + CString(pCDCDevice->m_commport);
 	}
-	
+	else
+	{
+		MxHidDevice* pHidDevice = dynamic_cast<MxHidDevice*>(((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->m_p_usb_port->GetDevice());
+		peripheral.Append(pHidDevice->_path.get());
+    }
+
 	retValue = (ExecuteBlhostCommand(CString(peripheral + _T(" -- ") + csCmdBody), csCmdText));
 	if ( retValue == ERROR_SUCCESS)
 	{


### PR DESCRIPTION
- If the current device is a hub device or it's parent is a hub device,
  this deivce is the usb device to find.
- Add compatibleIds. Check class type in the compatibleIds string to check
  whether the device is hub.
- Root hub has no class type, then check it's description. If the
  description has the string 'hub', then recognize it as a hub.

Signed-off-by: Yitao Zhang <yitao.zhang@nxp.com>