### PR TITLE
TestPrgm: allow building inside a build system

### DIFF
--- a/TestPrgm/Makefile
+++ b/TestPrgm/Makefile
@@ -1,13 +1,13 @@
-CC=g++
-CFLAGS= -L . -Wl,-rpath=. -l MfgToolLib -I../MfgToolLib -I/usr/include/libusb-1.0 -l usb-1.0 -g -l stdc++ -std=c++11 -l pthread  -fpermissive -Wno-write-strings
-
+CC ?= g++
+CMAKE ?= cmake
+CFLAGS ?= -L . -Wl,-rpath=. -l MfgToolLib -I../MfgToolLib -I/usr/include/libusb-1.0 -l usb-1.0 -g -l stdc++ -std=c++11 -l pthread  -fpermissive -Wno-write-strings
 
 default:
 	cd ../MfgToolLib && make
 	cp ../MfgToolLib/libMfgToolLib.so ./
 	$(CC) mfgtoolCLI.cpp $(CFLAGS) -o mfgtoolcli
 cmake:
-	cd ../MfgToolLib && cmake .
+	cd ../MfgToolLib && $(CMAKE) .
 clean:
 	rm ./mfgtoolcli
 	cd ../MfgToolLib && make clean


### PR DESCRIPTION
Removing hardcoded values for all the building tools such as g++
or cmake allows to build this package as part of Buildroot for
instance.

Buildroot package will be created once this patch gets merged.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>