### PR TITLE
[New Feature] Add "Blhost" state for Kinetis Bootloader.

### DIFF
--- a/Apps/MfgToolLib/CmdOperation.cpp
+++ b/Apps/MfgToolLib/CmdOperation.cpp
@@ -207,8 +207,11 @@ MX_DEVICE_STATE CCmdOpreation::GetDeviceState()
 	case DeviceClass::DeviceTypeHid:
 	case DeviceClass::DeviceTypeMxHid:
 	case DeviceClass::DeviceTypeMxRom:
-	case DeviceClass::DeviceTypeKBLCDC:
 		state = MX_BOOTSTRAP;
+		break;
+	case DeviceClass::DeviceTypeKBLCDC:
+	case DeviceClass::DeviceTypeKBLHID:
+		state = MX_BLHOST;
 		break;
 	case DeviceClass::DeviceTypeMsc:
 	case DeviceClass::DeviceTypeDisk:

--- a/Apps/MfgToolLib/DeviceClass.h
+++ b/Apps/MfgToolLib/DeviceClass.h
@@ -44,14 +44,15 @@ public:
 	typedef enum __DeviceClassType
 	{
         DeviceTypeNone = -1,
-		DeviceTypeDisk = 0,
+        DeviceTypeDisk = 0,
         DeviceTypeMsc,			//Updater stage(the second stage)
         DeviceTypeHid,
         DeviceTypeMxHid,
         DeviceTypeMxRom,
         DeviceTypeUsbController,
         DeviceTypeUsbHub,
-		DeviceTypeKBLCDC,
+        DeviceTypeKBLHID,
+        DeviceTypeKBLCDC,
     } DEV_CLASS_TYPE;
 
 	typedef struct NotifyStruct

--- a/Apps/MfgToolLib/KblHidDeviceClass.cpp
+++ b/Apps/MfgToolLib/KblHidDeviceClass.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2009-2013, Freescale Semiconductor, Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the Freescale Semiconductor nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "stdafx.h"
+#include <Assert.h>
+#include <cfgmgr32.h>
+#include <basetyps.h>
+#include <setupapi.h>
+#include <initguid.h>
+extern "C" {
+#include <hidsdi.h>
+}
+#include <hidclass.h>
+#include "DeviceClass.h"
+#include "MxHidDevice.h"
+#include "KblHidDeviceClass.h"
+#include "MfgToolLib_Export.h"
+#include "MfgToolLib.h"
+
+KblHidDeviceClass::KblHidDeviceClass(INSTANCE_HANDLE handle)
+: DeviceClass(&GUID_DEVINTERFACE_HID, &GUID_DEVCLASS_HIDCLASS, _T("KBLHID"), DeviceTypeKBLHID, handle)
+{
+	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("new KBLHidDeviceClass"));
+}
+
+KblHidDeviceClass::~KblHidDeviceClass(void)
+{
+	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("delete MxHidDeviceClass"));
+}
+
+Device* KblHidDeviceClass::CreateDevice(DeviceClass* deviceClass, SP_DEVINFO_DATA deviceInfoData, CString path)
+{
+    //Check if the path matches our device pid&vid.
+    //An example of value of path: "\\?\hid#vid_413c&pid_2011&mi_01&col02#8&2598dfbd&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}"
+
+    //add filiters
+	OP_STATE_ARRAY *pOpStates = GetOpStates((MFGLIB_VARS *)m_pLibHandle);
+	CString filter;
+	BOOL isRightDevice = FALSE;
+	OP_STATE_ARRAY::iterator it = pOpStates->begin();
+	COpState *pCurrentState = NULL;
+	CString msg = path;
+	for(; it!=pOpStates->end(); it++)
+	{
+		filter.Format(_T("vid_%04x&pid_%04x"), (*it)->uiVid, (*it)->uiPid);
+		//path.MakeUpper();
+		msg.MakeUpper();
+		filter.MakeUpper();
+		if( msg.Find(filter) != -1 )
+		{	//find
+			isRightDevice = TRUE;
+			pCurrentState = (*it);
+			break;
+		}
+	}
+	if(isRightDevice) //OK, find the device
+	{
+		return new MxHidDevice(deviceClass, deviceInfoData.DevInst, path, m_pLibHandle);
+	}
+	else
+	{
+		return NULL;
+	}
+}

--- a/Apps/MfgToolLib/KblHidDeviceClass.h
+++ b/Apps/MfgToolLib/KblHidDeviceClass.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2009-2013, Freescale Semiconductor, Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the Freescale Semiconductor nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+#include "DeviceClass.h"
+
+class KblHidDeviceClass : public DeviceClass
+{
+public:
+	KblHidDeviceClass(INSTANCE_HANDLE handle);
+    virtual ~KblHidDeviceClass(void);
+
+	Device* CreateDevice(DeviceClass* deviceClass, SP_DEVINFO_DATA deviceInfoData, CString path);
+
+    CString ToString() { return _T("KblHidDeviceClass"); }
+};

--- a/Apps/MfgToolLib/MfgToolLib.cpp
+++ b/Apps/MfgToolLib/MfgToolLib.cpp
@@ -953,6 +953,10 @@ DWORD ParseUclXml(MFGLIB_VARS *pLibVars)
 		{
 		   pState->opState = MX_UPDATER;
 		}
+		else if (strTemp.CompareNoCase(_T("Blhost")) == 0)
+		{
+			pState->opState = MX_BLHOST;
+		}
 		else
 		{
 			LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("Error: Invalid state name: %s"), strTemp);
@@ -1295,6 +1299,10 @@ DWORD ParseUclXml(MFGLIB_VARS *pLibVars)
 		else if(strState.CompareNoCase(_T("Updater")) == 0)
 		{
 			pLibVars->g_StateCommands[MX_UPDATER].push_back(pOpCmd);
+		}
+		else if (strState.CompareNoCase(_T("Blhost")) == 0)
+		{
+			pLibVars->g_StateCommands[MX_BLHOST].push_back(pOpCmd);
 		}
 	}
 	return MFGLIB_ERROR_SUCCESS;
@@ -2368,6 +2376,7 @@ UINT COpCmd_Blhost::ExecuteCommand(int index)
 	{
 		MxHidDevice* pHidDevice = dynamic_cast<MxHidDevice*>(((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->m_p_usb_port->GetDevice());
 		peripheral.Append(pHidDevice->_path.get());
+		LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_NORMAL_MSG, _T("PortMgrDlg(%d)--Path=%s"), index, pHidDevice->_path.get());
     }
 
 	retValue = (ExecuteBlhostCommand(CString(peripheral + _T(" -- ") + csCmdBody), csCmdText));
@@ -2761,9 +2770,10 @@ void AutoScanDevice(MFGLIB_VARS *pLibVars, int iPortUsedNums)
 					}
 					break;
 				case DeviceClass::DeviceTypeHid:
-                case DeviceClass::DeviceTypeMxHid:
+				case DeviceClass::DeviceTypeMxHid:
 				case DeviceClass::DeviceTypeMxRom:
 				case DeviceClass::DeviceTypeKBLCDC:
+				case DeviceClass::DeviceTypeKBLHID:
 					{
 						strPath = pPort->GetDevice()->_path.get();
 						strPath.MakeUpper();

--- a/Apps/MfgToolLib/MfgToolLib_2015.vcxproj
+++ b/Apps/MfgToolLib/MfgToolLib_2015.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="HidDevice.cpp" />
     <ClCompile Include="HidDeviceClass.cpp" />
     <ClCompile Include="HubClass.cpp" />
+    <ClCompile Include="KblHidDeviceClass.cpp" />
     <ClCompile Include="KernelApi.cpp" />
     <ClCompile Include="LogMgr.cpp" />
     <ClCompile Include="MfgToolLib.cpp" />
@@ -182,6 +183,7 @@
     <ClInclude Include="HidDevice.h" />
     <ClInclude Include="HidDeviceClass.h" />
     <ClInclude Include="HubClass.h" />
+    <ClInclude Include="KblHidDeviceClass.h" />
     <ClInclude Include="KernelApi.h" />
     <ClInclude Include="LogMgr.h" />
     <ClInclude Include="MfgToolLib.h" />

--- a/Apps/MfgToolLib/MfgToolLib_2015.vcxproj.filters
+++ b/Apps/MfgToolLib/MfgToolLib_2015.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClCompile Include="XMLite.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="KblHidDeviceClass.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="MfgToolLib.def">
@@ -266,6 +269,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="CdcDeviceClass.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="KblHidDeviceClass.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Apps/MfgToolLib/MfgToolLib_Export.h
+++ b/Apps/MfgToolLib/MfgToolLib_Export.h
@@ -110,6 +110,7 @@ typedef enum _Device_State
 {
 	MX_BOOTSTRAP = 0,
 	MX_UPDATER,
+	MX_BLHOST,
 	MX_DISCONNECTED = 10,
 } MX_DEVICE_STATE;
 

--- a/Apps/MfgToolLib/UsbPort.cpp
+++ b/Apps/MfgToolLib/UsbPort.cpp
@@ -332,6 +332,7 @@ CString usb::Port::GetDeviceDescription(void)
                 case DeviceClass::DeviceTypeMxHid:
                 case DeviceClass::DeviceTypeUsbController:
                 case DeviceClass::DeviceTypeUsbHub:
+                case DeviceClass::DeviceTypeKBLHID:
                 default:
                     descStr = _device->_description.get().GetBuffer();
 					_device->_description.get().ReleaseBuffer();

--- a/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
+++ b/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
@@ -953,6 +953,9 @@ void StartForConsole()
 			case MX_UPDATER:
 				strPhase = _T("Updater phase: ");
 				break;
+			case MX_BLHOST:
+				strPhase = _T("Blhost phase: ");
+				break;
 			}
 			strMsg.Format(_T("Device %d - %s%d%%"), (i+1), strPhase, 0);
 		}


### PR DESCRIPTION
- Separate KBL-HID from MxHID.
- Add "Blhost" state.
- KBL-CDC device and KBL-HID device belongs to "Blhost" state.

Signed-off-by: Yitao Zhang <yitao.zhang@nxp.com>