### PR TITLE
[New Feature] Support encrypted manufacturing

### DIFF
--- a/Apps/MfgToolLib/CmdOperation.cpp
+++ b/Apps/MfgToolLib/CmdOperation.cpp
@@ -452,6 +452,7 @@ UINT CmdListThreadProc(LPVOID pParam)
 	OP_COMMAND_ARRAY::iterator cmdIt;
 	DWORD dwStateIndex = 0;
 	CString chip;
+	MxHidDevice::HAB_t habstate = MxHidDevice::HabUnknown;
 
 	while(!pOperation->m_bKilled)
 	{
@@ -512,11 +513,12 @@ UINT CmdListThreadProc(LPVOID pParam)
 					if(pDevice->GetDeviceType() == DeviceClass::DeviceTypeMxHid)
 					{
 						chip = ((MxHidDevice*)pDevice)->_chiFamilyName;
+						habstate = ((MxHidDevice*)pDevice)->GetHABState();
 					}
 				}
 				
 				COpCommand *pCmd = (*cmdIt);
-				if(pCmd->IsRun(chip))
+				if(pCmd->IsRun(chip) && pCmd->IsRun(habstate))
 				{
 					dwError = pCmd->ExecuteCommand(pOperation->m_WndIndex);
 				}else

--- a/Apps/MfgToolLib/MfgToolLib.cpp
+++ b/Apps/MfgToolLib/MfgToolLib.cpp
@@ -1292,6 +1292,9 @@ DWORD ParseUclXml(MFGLIB_VARS *pLibVars)
 		strTemp = (*it)->GetAttrValue(_T("ifdev"));
 		pOpCmd->SetIfDevString(strTemp);
 
+		strTemp = (*it)->GetAttrValue(_T("ifhab"));
+		pOpCmd->SetIfHabString(strTemp);
+
 		if( strState.CompareNoCase(_T("BootStrap")) == 0 )
 		{
 			pLibVars->g_StateCommands[MX_BOOTSTRAP].push_back(pOpCmd);
@@ -1424,6 +1427,11 @@ void COpCommand::SetIfDevString(CString &str)
 	m_ifdev = str;
 }
 
+void COpCommand::SetIfHabString(CString &str)
+{
+	m_ifhab = str;
+}
+
 bool COpCommand::IsRun(CString &str)
 {
 	if (m_ifdev.IsEmpty())
@@ -1436,6 +1444,37 @@ bool COpCommand::IsRun(CString &str)
 	{
 		substr = m_ifdev.Tokenize(_T(" ,;\n\t"), start);
 		if (substr == str)
+			return true;
+	}
+
+	return false;
+}
+
+bool COpCommand::IsRun(MxHidDevice::HAB_t habState)
+{
+	if (m_ifhab.IsEmpty())
+		return true;
+
+	CString stateStr;
+	if (habState == MxHidDevice::HabDisabled)
+	{
+		stateStr = _T("Open");
+	}
+	else if (habState == MxHidDevice::HabEnabled)
+	{
+		stateStr = _T("Close");
+	}
+	else
+	{
+		stateStr = _T("Unknown");
+	}
+
+	int start = 0;
+	CString substr = m_ifhab;
+	while (start >= 0)
+	{
+		substr = m_ifhab.Tokenize(_T(" ,;\n\t"), start);
+		if (substr == stateStr)
 			return true;
 	}
 

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -49,7 +49,7 @@
 #include "UsbPort.h"
 #include "UpdateTransportProtocol.h"
 #include "CmdOperation.h"
-
+#include "MxHidDevice.h"
 
 // CMfgToolLibApp
 // See MfgToolLib.cpp for the implementation of this class
@@ -136,13 +136,16 @@ public:
 	virtual void SetDescString(CString &str);
 	virtual CString GetDescString();
 	virtual void SetIfDevString(CString &str);
+	virtual void SetIfHabString(CString &str);
 	virtual bool IsRun(CString &dev);
+	virtual bool IsRun(MxHidDevice::HAB_t habState);
 	INSTANCE_HANDLE m_pLibVars;
 
 protected:
 	CString m_bodyString;
 	CString m_descString;
 	CString m_ifdev;
+	CString m_ifhab;
 };
 
 class COpCmd_Find : public COpCommand

--- a/Apps/MfgToolLib/MxHidDevice.h
+++ b/Apps/MfgToolLib/MxHidDevice.h
@@ -263,6 +263,7 @@ public:
 	ChipFamily_t _chipFamily;
 	CString		_chiFamilyName;
 	UINT m_jumpAddr;
+	HAB_t m_habState;
 
 	static MemorySection StringToMemorySection(CString section)
 	{
@@ -302,6 +303,7 @@ public:
 	BOOL SendCmd(PSDPCmd pSDPCmd);
 	BOOL SendData(const unsigned char * DataBuf, UINT ByteCnt);
 	BOOL GetHABType();
+	HAB_t GetHABState();
 	BOOL GetDevAck(UINT RequiredCmdAck);  
 	VOID PackSDPCmd(PSDPCmd pSDPCmd);
 	int Read(void* buf, UINT size);


### PR DESCRIPTION
- Add "ifhab" parameter for xml commands. ifhab="Open" for HAB disabled,
while ifhab="Close" for HAB enabled.
- Get HAB state at the first time detecting MxHid device.
- Send "Error Status" command to get the HAB state.

Signed-off-by: Yitao Zhang <yitao.zhang@nxp.com>