### PR TITLE
modern cmake: set cxx standard instead of modifying flags directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(libuuu)
 add_subdirectory(uuu)

--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(Threads)
 
 include_directories(${LIBUSB_INCLUDE_DIRS} include)
 
-set(CMAKE_CXX_FLAGS "-std=c++11")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wstrict-aliasing -Wextra")
 
 set(SOURCES

--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -4,7 +4,7 @@ pkg_check_modules(LIBZIP REQUIRED libzip)
 pkg_check_modules(LIBZ REQUIRED zlib)
 find_package(Threads)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -pthread -static-libstdc++ -static-libgcc")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -static-libstdc++ -static-libgcc")
 
 set(LSTS
 	uuu.lst


### PR DESCRIPTION
Signed-off-by: Niklas Johansson <niklas.johansson@prevas.dk>