### PR TITLE
Fix polling loop

### DIFF
--- a/MfgToolLib/libusbVolume.cpp
+++ b/MfgToolLib/libusbVolume.cpp
@@ -160,17 +160,11 @@ UINT libusbVolume::SendCommand(HANDLE hDrive, StApi& api, UCHAR* additionalInfo,
 		response = uResponse.bCSWStatus;
 		cont = false;
 
-		if (senseResponse.UTPSenseCode == 0x8002)
+		if (senseResponse.UTPSenseCode == 0x280)
 		{
 			CSW_UTP psResponse;
-			int response = pollDevice(&psResponse, api);
-				if (response == 0 && !&psResponse)
-				{
-					if (psResponse.bCSWStatus == 1)
-						cont = true;
-					else
-						cont = false;
-				}
+			pollDevice(&psResponse, api);
+			cont = true;
 		}
 
 		//Sleep is needed or else the computer will spam the device with requests causing malfunctions


### PR DESCRIPTION
The UtpSenseCode check wasn't done in the correct byte order so
SendCommand never actually went into the polling loop.

After fixing that it turned out it would only ever do a loop once as
bCSWStatus was never 1 in response to a poll request. To fix that simply
always go around the loop again after a poll to check the current Sense
response.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>