### PR TITLE
lookup libbz2 not by filename but by library name

### DIFF
--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -51,6 +51,6 @@ set(SOURCES
 )
 
 add_executable(uuu ${SOURCES})
-target_link_libraries(uuu uuc_s  ${LIBUSB_LIBRARIES} ${LIBZIP_LIBRARIES} ${LIBZ_LIBRARIES} libbz2.a)
+target_link_libraries(uuu uuc_s  ${LIBUSB_LIBRARIES} ${LIBZIP_LIBRARIES} ${LIBZ_LIBRARIES} bz2)
 
 install(TARGETS uuu DESTINATION bin)


### PR DESCRIPTION
Hello,

I'm using Arch Linux and `libbz2` is installed as a shared object. 

`target_link_libraries` can find libraries with their name. So I updated it to use a name instead of full archive file.

Thank you