### PR TITLE
Nsjo/notify string

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -44,8 +44,8 @@
 #include <sys/stat.h>
 #include <thread>
 
-#include <stdio.h>  
-#include <stdlib.h>  
+#include <stdio.h>
+#include <stdlib.h>
 
 static CmdMap g_cmd_map;
 static CmdObjCreateMap g_cmd_create_map;
@@ -156,7 +156,7 @@ int CmdList::run_all(CmdCtx *p, bool dry_run)
 			call_notify(nt);
 
 			nt.type = uuu_notify::NOTIFY_CMD_START;
-			nt.str = (char *)(*it)->m_cmd.c_str();
+			nt.text = (*it)->m_cmd;
 			call_notify(nt);
 
 			ret = (*it)->run(p);
@@ -344,14 +344,14 @@ int uuu_run_cmd(const char * cmd)
 	call_notify(nt);
 
 	nt.type = uuu_notify::NOTIFY_CMD_START;
-	nt.str = (char *)p->m_cmd.c_str();
+	nt.text = p->m_cmd;
 	call_notify(nt);
 
 	if (typeid(*p) != typeid(CfgCmd))
 	{
 		size_t pos = 0;
 		string c = cmd;
-		
+
 		string pro = get_next_param(c, pos, ':');
 		pro = remove_square_brackets(pro);
 		pro += ":";
@@ -465,7 +465,7 @@ int CmdShell::run(CmdCtx*)
 			str.resize(strlen(str.c_str()));
 			cmd += ' ';
 			cmd += str;
-			
+
 			size_t pos = cmd.find_first_of("\r\n");
 			if (pos != string::npos)
 				cmd = cmd.substr(0, pos);
@@ -474,7 +474,7 @@ int CmdShell::run(CmdCtx*)
 		}
 		uuu_notify nt;
 		nt.type = uuu_notify::NOTIFY_CMD_INFO;
-		nt.str = (char*)str.c_str();
+		nt.text = str;
 		call_notify(nt);
 	}
 

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -79,14 +79,13 @@ int FastBoot::Transport(string cmd, void *p, size_t size, vector<uint8_t> *input
 				if (m_pTrans->write(p, sz))
 					return -1;
 			}
-		}else
-		{
+		} else {
 			string s;
 			s = buff + 4;
 			m_info += s;
 			uuu_notify nt;
 			nt.type = uuu_notify::NOTIFY_CMD_INFO;
-			nt.str = buff + 4;
+			nt.text = std::string(buff + 4);
 			call_notify(nt);
 		}
 	}
@@ -145,10 +144,10 @@ int FBCmd::parser(char *p)
 
 	size_t pos = 0;
 	string s;
-	
+
 	if (parser_protocal(p, pos))
 		return -1;
-	
+
 	s = get_next_param(m_cmd, pos);
 
 	if (str_to_upper(s) != str_to_upper(m_fb_cmd))

--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -31,8 +31,7 @@
 
 #pragma once
 
-#include <cstdint>
-#include <cstddef>
+#include <string>
 
 /**
  * Get Last error string
@@ -88,12 +87,12 @@ struct uuu_notify
 
 	NOTIFY_TYPE type;
 	uint64_t id;
+	std::string text;
 	union
 	{
 		int status;
 		size_t index;
 		size_t total;
-		char *str;
 	};
 };
 

--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -31,8 +31,8 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
+#include <cstdint>
+#include <cstddef>
 
 /**
  * Get Last error string

--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -28,38 +28,32 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 */
-#ifndef __libuuu___
-#define __libuuu___
+
+#pragma once
 
 #include <stdint.h>
 #include <stddef.h>
-
-#ifdef __cplusplus
-#define EXT extern "C"
-#else
-#define EXT
-#endif
 
 /**
  * Get Last error string
  * @return last error string
 */
-EXT const char * uuu_get_last_err_string();
+const char * uuu_get_last_err_string();
 
 /**
 * Get Last error code
 * @return last error code
 */
-EXT int uuu_get_last_err();
+int uuu_get_last_err();
 
-EXT const char * uuu_get_version_string();
+const char * uuu_get_version_string();
 
 /**
  * 1.0.1
  * bit[31:24].bit[23:16].bit[15:0]
  */
 
-EXT int uuu_get_version();
+int uuu_get_version();
 
 
 
@@ -85,7 +79,7 @@ struct uuu_notify
 
 		NOTIFY_DECOMPRESS_START,
 		NOTIFY_DECOMPRESS_SIZE,
-		NOTIFY_DECOMPRESS_POS, 
+		NOTIFY_DECOMPRESS_POS,
 
 		NOTIFY_THREAD_EXIT,
 
@@ -126,5 +120,3 @@ int uuu_add_usbpath_filter(const char *path);
  * bit 16:31 for uuu
  */
 void uuu_set_debug_level(uint32_t mask);
-
-#endif

--- a/libuuu/sdp.cpp
+++ b/libuuu/sdp.cpp
@@ -228,7 +228,7 @@ int SDPWriteCmd::run(CmdCtx*ctx)
 		size = pDB->ImageSize;
 
 		//ImageSize may be bigger than Imagesize because ImageSize include IVT offset
-		//Difference boot storage have difference IVT offset. 
+		//Difference boot storage have difference IVT offset.
 		if (size > fbuff->size() - off)
 			size = fbuff->size() - off;
 
@@ -367,7 +367,7 @@ int SDPBootlogCmd::run(CmdCtx *ctx)
 
 	uuu_notify nt;
 	nt.type = uuu_notify::NOTIFY_CMD_INFO;
-	
+
 	int ret;
 	while (1)
 	{
@@ -376,8 +376,7 @@ int SDPBootlogCmd::run(CmdCtx *ctx)
 			return 0;
 		else
 		{
-			nt.str = (char*)(v.data() + 4);
-			v[5] = 0;
+			nt.text = std::string(v.data() + 4, v.data() + 5);
 			call_notify(nt);
 			continue;
 		}

--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -99,7 +99,7 @@ static int run_usb_cmds(ConfigItem *item, libusb_device *dev)
 
 	string str;
 	str = get_device_path(dev);
-	nt.str = (char*)str.c_str();
+	nt.text = str;
 	call_notify(nt);
 
 	CmdUsbCtx ctx;
@@ -311,7 +311,7 @@ int CmdUsbCtx::look_for_match_device(const char *pro)
 					}
 
 					libusb_free_device_list(list, 1);
-					nt.str = (char*)str.c_str();
+					nt.text = str;
 					call_notify(nt);
 
 					return 0;
@@ -323,7 +323,7 @@ int CmdUsbCtx::look_for_match_device(const char *pro)
 
 		uuu_notify nt;
 		nt.type = nt.NOTIFY_WAIT_FOR;
-		nt.str = (char*)"Wait for Known USB";
+		nt.text = "Wait for Known USB";
 		call_notify(nt);
 	}
 

--- a/libuuu/zip.h
+++ b/libuuu/zip.h
@@ -166,7 +166,7 @@ public:
 
 		uuu_notify ut;
 		ut.type = uuu_notify::NOTIFY_DECOMPRESS_START;
-		ut.str = (char*)filename.c_str();
+		ut.text = filename;
 		call_notify(ut);
 
 		return m_filemap[filename].decompress(this);

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -289,14 +289,14 @@ public:
 	{
 		if (nt.type == uuu_notify::NOFITY_DEV_ATTACH)
 		{
-			m_dev = nt.str;
+			m_dev = nt.text;
 			m_done = 0;
 			m_status = 0;
 		}
 		if (nt.type == uuu_notify::NOTIFY_CMD_START)
 		{
 			m_start_pos = 0;
-			m_cmd = nt.str;
+			m_cmd = nt.text;
 		}
 		if (nt.type == uuu_notify::NOTIFY_TRANS_SIZE)
 		{
@@ -350,11 +350,11 @@ public:
 	{
 		if (nt->type == uuu_notify::NOFITY_DEV_ATTACH)
 		{
-			cout << "New USB Device Attached at " << nt->str << endl;
+			cout << "New USB Device Attached at " << nt->text << endl;
 		}
 		if (nt->type == uuu_notify::NOTIFY_CMD_START)
 		{
-			cout << m_dev << ">" << "Start Cmd:" << nt->str << endl;
+			cout << m_dev << ">" << "Start Cmd:" << nt->text << endl;
 		}
 		if (nt->type == uuu_notify::NOTIFY_CMD_END)
 		{
@@ -379,10 +379,10 @@ public:
 		}
 
 		if (nt->type == uuu_notify::NOTIFY_CMD_INFO)
-			cout << nt->str;
+			cout << nt->text;
 
 		if (nt->type == uuu_notify::NOTIFY_WAIT_FOR)
-			cout << "\r" << nt->str << " "<< g_wait[((g_wait_index++) & 0x3)];
+			cout << "\r" << nt->text << " "<< g_wait[((g_wait_index++) & 0x3)];
 	}
 	void print(int verbose = 0, uuu_notify*nt=NULL)
 	{


### PR DESCRIPTION
upgrade char * logic to c++ std string
    
By upgrading the string in the notify type to a c++
standard string we avoid a lot of c point gymnastics.
Especially because we use std strings in the end most
of the times any ways.
