### PR TITLE
set the CMAKE_CXX_STANDARD to c++11 explicitly to

### DIFF
--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -1,3 +1,8 @@
+cmake_minimum_required(VERSION 3.4)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUSB REQUIRED libusb-1.0>=1.0.16)
 pkg_check_modules(LIBZIP REQUIRED libzip)

--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -1,3 +1,8 @@
+cmake_minimum_required(VERSION 3.4)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUSB REQUIRED libusb-1.0>=1.0.16)
 pkg_check_modules(LIBZIP REQUIRED libzip)


### PR DESCRIPTION
fix the compile error on Mac OSX.

Signed-off-by: Shenwei Wang <shenwei.wang@nxp.com>