### PR TITLE
libuuu: remove redefinitions of ROM_WRITE_ACK, ROM_STATUS_ACK and ROM_OK_ACK

### DIFF
--- a/libuuu/sdp.h
+++ b/libuuu/sdp.h
@@ -85,10 +85,6 @@ struct BootData
 
 #define HAB_TAG_DCD							0xd2       /**< Device Configuration Data */
 
-#define ROM_WRITE_ACK						0x128A8A12
-#define ROM_STATUS_ACK					0x88888888
-#define ROM_OK_ACK						0x900DD009
-
 class SDPCmdBase:public CmdBase
 {
 public:


### PR DESCRIPTION
Remove redefinition of the macro ROM_WRITE_ACK