### PR TITLE
Don't build binaries with a broken gitversion

### DIFF
--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -32,12 +32,14 @@ set(SOURCES
 )
 
 set(generated_files_dir "${CMAKE_BINARY_DIR}/libuuu/gen")
+set(gitversion_h "${generated_files_dir}/gitversion.h")
 
 add_custom_command(
 	OUTPUT gitversion.h
 	PRE_BUILD
 	COMMAND mkdir -p ${generated_files_dir}
-	COMMAND sh -c 'cd ${CMAKE_CURRENT_SOURCE_DIR} && ./gen_ver.sh ${generated_files_dir}/gitversion.h'
+	COMMAND sh -c 'cd ${CMAKE_CURRENT_SOURCE_DIR} && rm -f ${gitversion_h} && ./gen_ver.sh "${gitversion_h}.tmp" && mv -f "${gitversion_h}.tmp" "${gitversion_h}"'
+
 )
 include_directories(${generated_files_dir})
 

--- a/libuuu/gen_ver.sh
+++ b/libuuu/gen_ver.sh
@@ -3,6 +3,8 @@
 # Input parameters
 file_to_write="$1"
 
+set -e
+
 if [ "${APPVEYOR_BUILD_VERSION}" = "" ];
 then
 	echo build not in appveyor

--- a/libuuu/version.cpp
+++ b/libuuu/version.cpp
@@ -36,10 +36,6 @@
 
 using namespace std;
 
-#ifndef GIT_VERSION
-#define GIT_VERSION "v1.1.4-unknown"
-#endif
-
 static const char g_version[] = GIT_VERSION;
 
 const char *uuu_get_version_string()


### PR DESCRIPTION
This leads to runtime crashes (See #98)