### PR TITLE
Typo in Debian/Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The prebuilt image and document are here:
 ## Linux
 - git clone https://github.com/NXPmicro/mfgtools.git
 - cd mfgtools
-- sudo apt-get install libusb-1.0.0-dev libzip-dev libbz2-dev pkg-config
+- sudo apt-get install libusb-1.0-0-dev libzip-dev libbz2-dev pkg-config
 - cmake .
 - make
 


### PR DESCRIPTION
The package is called "libusb-1.0-0-dev" not "libusb-1.0.0-dev".
Source: https://packages.debian.org/de/sid/libusb-1.0-0-dev https://packages.ubuntu.com/bionic/libusb-1.0-0-dev