### PR TITLE
Increase string size for device numeration

### DIFF
--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -396,7 +396,7 @@ public:
 	{
 		string str;
 		str = m_dev;
-		str.resize(6, ' ');
+		str.resize(8, ' ');
 
 		string_ex s;
 		s.format("%2d/%2d", m_cmd_index+1, m_cmd_total);


### PR DESCRIPTION
Device enumerations might be longer than six digits, e.g. on my system...

without the patch:
```
2:441219/19 [Done                                  ] FB: done                                                                                               
2:441419/19 [Done                                  ] FB: done
```

with the patch:
```
2:4412  19/19 [Done                                  ] FB: done                                                                                               
2:44142 19/19 [Done                                  ] FB: done
```