### PR TITLE
fixed mfgtool can not find usb storage on windows 10

### DIFF
--- a/Apps/MfgToolLib/VolumeDeviceClass.cpp
+++ b/Apps/MfgToolLib/VolumeDeviceClass.cpp
@@ -90,7 +90,10 @@ Device* VolumeDeviceClass::CreateDevice(DeviceClass* deviceClass, SP_DEVINFO_DAT
 	Volume* volume = new Volume(deviceClass, deviceInfoData.DevInst, path, m_pLibHandle);
 	
 	// Only Create USB Volumes
-	if ( volume->IsUsb() )
+	// begin comment out volume->isUsb()
+	// volume->IsUsb() checking is unbelievable, use rest condition check it;
+	// if (volume->IsUsb() )
+	//end	comment out volume->isUsb()
 	{
 		Disk* pdisk;
 		pdisk = volume->StorageDisk();


### PR DESCRIPTION
in updater stage.
VolumeDeviceClass::IsUsb() checking usb device keywords
in logic driver device path, maybe window driver rules has been
changed. sometimes the result is untrustable.

Signed-off-By: zarelaky <zarelaky@hotmail.com>