### PR TITLE
allow true dynamic linking for Linux build

### DIFF
--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Threads)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O2")
 
-if (NOT APPLE)
+if (WIN32)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
 endif()
 


### PR DESCRIPTION
Currently the binary generated from a Linux build is dynamically linked
but we force the static version for libstdc++ and libgcc.

This seems to be needed for Windows which only supports static linking
apparently.

Let's use the standard dynamic libraries for Linux to ease the tool
integration into Buildroot build system [1].

[1] http://lists.busybox.net/pipermail/buildroot/2019-May/250858.html

Signed-off-by: Gary Bisson <bisson.gary@gmail.com>