### PR TITLE
allow true dynamic linking for Linux build

### DIFF
--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Threads)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O2")
 
-if (NOT APPLE)
+if (STATIC)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
 endif()
 


### PR DESCRIPTION
Currently the binary generated from a Linux build is dynamically linked
but we force the static version for libstdc++ and libgcc.

Let's use the standard dynamic libraries for Linux to ease the tool
integration into Buildroot build system [1].

But also keep the option to build with the static stdc++ libraries as
some people apparently need it:
 `# cmake -D'STATIC=1' .`
 `# make`

[1] http://lists.busybox.net/pipermail/buildroot/2019-May/250858.html

Signed-off-by: Gary Bisson <bisson.gary@gmail.com>