### PR TITLE
Fix missing sstream

### DIFF
--- a/Apps/MfgToolLib/XMLite.h
+++ b/Apps/MfgToolLib/XMLite.h
@@ -36,6 +36,7 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
+#include <sstream>
 #include <vector>
 #include <deque>
 


### PR DESCRIPTION
_"basic_ostringstream": is not a member of 'std'_ reported in vs2019