### PR TITLE
decrease the download size for smaller DRAM

### DIFF
--- a/libuuu/fastboot.h
+++ b/libuuu/fastboot.h
@@ -150,6 +150,6 @@ public:
 	bool m_bDownload;
 	size_t m_Maxsize_pre_cmd;
 	int parser(char *p=NULL);
-	FBCopy(char *p) :CmdBase(p) { m_Maxsize_pre_cmd = 0x10000; };
+	FBCopy(char *p) :CmdBase(p) { m_Maxsize_pre_cmd = 0x1000; };
 	int run(CmdCtx *ctx);
 };


### PR DESCRIPTION
decreasing the download size to 4K for small DRAM (like 256M). it would be temporal workaround.
