### PR TITLE
change the nand lst for nandbcb support

### DIFF
--- a/uuu/nand_burn_loader.lst
+++ b/uuu/nand_burn_loader.lst
@@ -28,5 +28,7 @@ SDPV: jump
 
 FB: ucmd setenv fastboot_buffer ${loadaddr}
 FB: download -f _image
-FB: nandbcb update ${fastboot_buffer} nandboot ${fastboot_bytes}
+# Burn image to nandfit partition if needed
+FB: ucmd if env exists nandfit_part; then nand erase.part nandfit; nand write ${fastboot_buffer} nandfit ${fastboot_bytes}; fi;
+FB: nandbcb init ${fastboot_buffer} nandboot ${fastboot_bytes}
 FB: Done


### PR DESCRIPTION
change the default nandbcb command from update to init, which is same as
the kobs-ng, update will be used for futher partially update function.

burn nandfit partition if necessary.

Signed-off-by: Han Xu <han.xu@nxp.com>