### PR TITLE
sdp: bootcmd: add support for -dcdaddr

### DIFF
--- a/libuuu/sdp.cpp
+++ b/libuuu/sdp.cpp
@@ -101,7 +101,7 @@ int SDPDcdCmd::run(CmdCtx*ctx)
 	uint32_t size = (pdcd[1] << 8) | pdcd[2];
 
 	m_spdcmd.m_cmd = ROM_KERNEL_CMD_DCD_WRITE;
-	m_spdcmd.m_addr = EndianSwap(rom->free_addr);
+	m_spdcmd.m_addr = EndianSwap(m_dcd_addr ? m_dcd_addr : rom->free_addr);
 	m_spdcmd.m_count = EndianSwap(size);
 
 	HIDTrans dev;
@@ -142,6 +142,10 @@ int SDPBootCmd::run(CmdCtx *ctx)
 	string str;
 	str = "SDP: dcd -f ";
 	str += m_filename;
+	if (m_dcd_addr) {
+		str += " -dcdaddr ";
+		str += std::to_string(m_dcd_addr);
+	}
 	SDPDcdCmd dcd((char *)str.c_str());
 	if (dcd.parser()) return -1;
 	if (dcd.run(ctx)) return -1;

--- a/libuuu/sdp.h
+++ b/libuuu/sdp.h
@@ -171,10 +171,13 @@ public:
 class SDPDcdCmd : public SDPCmdBase
 {
 public:
+	uint32_t m_dcd_addr;
 	SDPDcdCmd(char *p):SDPCmdBase(p)
 	{
 		insert_param_info("dcd", NULL, Param::e_null);
 		insert_param_info("-f", &m_filename, Param::e_string_filename);
+		insert_param_info("-dcdaddr", &m_dcd_addr, Param::e_uint32);
+		m_dcd_addr = 0;
 	}
 	int run(CmdCtx *);
 
@@ -290,12 +293,15 @@ class SDPBootCmd : public SDPCmdBase
 {
 public:
 	bool m_nojump;
+	uint32_t m_dcd_addr;
 	SDPBootCmd(char *p) : SDPCmdBase(p)
 	{
 		insert_param_info("boot", NULL, Param::e_null);
 		insert_param_info("-f", &m_filename, Param::e_string_filename);
 		insert_param_info("-nojump", &m_nojump, Param::e_bool);
+		insert_param_info("-dcdaddr", &m_dcd_addr, Param::e_uint32);
 		m_nojump = false;
+		m_dcd_addr = 0;
 	}
 	int run(CmdCtx *p);
 };


### PR DESCRIPTION
Allows the user to chose the DCD location in the bootcmd. This is
often the case when trying to upgrade a system that has already been
closed.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>