### PR TITLE
libuuu: fix race condition in device scan logic

### DIFF
--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -160,7 +160,7 @@ static int usb_add(libusb_device *dev)
 	if (item)
 	{
 		g_known_device_appeared = 1;
-		std::thread(run_usb_cmds, item, dev).detach();
+		std::thread(run_usb_cmds, item, dev).join();
 	}
 	return 0;
 }


### PR DESCRIPTION
When using libusb without libudev we encountered a Segmentation fault:
  Thread 1 "uuu" received signal SIGSEGV, Segmentation fault.
  0x0000000000000000 in ?? ()
  (gdb) bt
  #0  0x0000000000000000 in ?? ()
  #1  0x00000000006736b1 in __gthread_detach (__threadid=<optimized out>) at /usr/src/debug/gcc-runtime/9.2.0-r0/x86_64-poky-linux/libstdc++-v3/include/x86_64-poky-linux/bits/gthr-default.h:675
  #2  std::thread::detach (this=this@entry=0x7fffffffdb88) at ../../../../../../../../../../work-shared/gcc-9.2.0-r0/gcc-9.2.0/libstdc++-v3/src/c++11/thread.cc:124
  #3  0x0000000000436d7d in usb_add (dev=<optimized out>) at /usr/include/c++/9.2.0/bits/unique_ptr.h:75
  #4  0x0000000000436f85 in compare_list (old=<optimized out>, nw=<optimized out>) at /usr/src/debug/mfgtools/1.3.102+gitAUTOINC+b078bd087f-r0/git/libuuu/usbhotplug.cpp:181
  #5  compare_list (old=0x0, nw=<optimized out>) at /usr/src/debug/mfgtools/1.3.102+gitAUTOINC+b078bd087f-r0/git/libuuu/usbhotplug.cpp:172
  #6  0x0000000000437042 in polling_usb (bexit=...) at /usr/src/debug/mfgtools/1.3.102+gitAUTOINC+b078bd087f-r0/git/libuuu/usbhotplug.cpp:241
  #7  0x00000000004220b8 in uuu_wait_uuu_finish (deamon=deamon@entry=0, dry=dry@entry=0) at /usr/src/debug/mfgtools/1.3.102+gitAUTOINC+b078bd087f-r0/git/libuuu/cmd.cpp:782
  #8  0x0000000000409024 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/mfgtools/1.3.102+gitAUTOINC+b078bd087f-r0/git/uuu/uuu.cpp:1057

What seems to fix the issue is wait for the processing thread to
finish (using join() instead of detach()). I guess it is realted to
the libusb device reference which is no longer valid after compare_list
is finished. Joining on the thread seems to work reliably and seems to
have no adversive effects otherwise.

Signed-off-by: Stefan Agner <stefan.agner@toradex.com>