### PR TITLE
libuuu: fastboot: fix oem command separator

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -178,7 +178,7 @@ int FBCmd::run(CmdCtx *ctx)
 	FastBoot fb(&dev);
 	string cmd;
 	cmd = m_fb_cmd;
-	cmd += ":";
+	cmd += m_separator;
 	cmd += m_uboot_cmd;
 
 	if (fb.Transport(cmd, NULL, 0))

--- a/libuuu/fastboot.h
+++ b/libuuu/fastboot.h
@@ -70,7 +70,8 @@ class FBCmd: public CmdBase
 public:
 	string m_fb_cmd;
 	string m_uboot_cmd;
-	FBCmd(char *p) :CmdBase(p) {}
+	char m_separator;
+	FBCmd(char *p) :CmdBase(p), m_separator(':') {}
 	int parser(char *p = NULL);
 	int run(CmdCtx *ctx);
 };
@@ -102,7 +103,7 @@ public:
 class FBOemCmd : public FBCmd
 {
 public:
-	FBOemCmd(char *p) : FBCmd(p) { m_fb_cmd = "oem"; }
+	FBOemCmd(char *p) : FBCmd(p) { m_fb_cmd = "oem"; m_separator = ' ';}
 };
 
 class FBFlashCmd : public FBCmd


### PR DESCRIPTION
Android uses ' ' for oem command separation.

See: https://android.googlesource.com/platform/system/core/+/95b6f45b0e09b45daf6a7999cef039fabf587327/fastboot/fastboot.cpp#1483
See: https://android.googlesource.com/platform/system/core/+/95b6f45b0e09b45daf6a7999cef039fabf587327/fastboot/fastboot.cpp#1645
Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>