### PR TITLE
libuuu: allow to build without git

### DIFF
--- a/libuuu/gen_ver.sh
+++ b/libuuu/gen_ver.sh
@@ -5,6 +5,12 @@ file_to_write="$1"
 
 set -e
 
+if [ -f ../.tarball-version ]
+then
+	echo "#define GIT_VERSION \"lib$(cat ../.tarball-version)\"" > "$file_to_write"
+	exit 0
+fi
+
 if [ "${APPVEYOR_BUILD_VERSION}" = "" ];
 then
 	echo build not in appveyor


### PR DESCRIPTION
Read .tarball-version if pressent, instead of git description.

Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>
----
Hi,

this is an idea to fix  #77 .
A tarball source release will have to add the .tarball-version file.
For example with a script like:
```bash
version=$(git describe --tags)
mkdir "$version"
echo "$version" > "$version/.tarball-version"
git archive --prefix="$version/" HEAD > "$version.tar"
tar --append -f "$version.tar" "$version/.tarball-version"
gzip "$version.tar"
```