### PR TITLE
libuuu/CMakeLists.txt: don't overwrite CMAKE_CXX_FLAGS

### DIFF
--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${LIBUSB_INCLUDE_DIRS} ${UUUOPENSLL_INCLUDE_DIR} include)
 
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -Wstrict-aliasing -Wextra ${UUUSSL}")
-set(CMAKE_CXX_FLAGS "-O2 ${UUUSSL}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 ${UUUSSL}")
 
 set(SOURCES
 	error.cpp


### PR DESCRIPTION
Don't overwrite CMAKE_CXX_FLAGS in libuuu/CMakeLists.txt to fix build of
mfgtools on buildroot

See https://bugs.buildroot.org/show_bug.cgi?id=12391

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>