### PR TITLE
allow to pass sparse limit from command line

### DIFF
--- a/libuuu/fastboot.h
+++ b/libuuu/fastboot.h
@@ -113,6 +113,7 @@ public:
 	std::string m_partition;
 	uint64_t m_totalsize;
 	bool m_raw2sparse = false;
+	size_t m_sparse_limit = 0x1000000;
 	FBFlashCmd(char *p) : FBCmd(p, "flash") { m_timeout = 10000; }
 	int parser(char *p = nullptr) override;
 	int run(CmdCtx *ctx) override;


### PR DESCRIPTION
Like with Android fastboot
https://android.googlesource.com/platform/system/core/+/b407502c98ff62fe0b450fc1e6fd85682e533cac/fastboot/fastboot.cpp#1827
it is handy for differnet setups to pass to pass the sparse limit by command line.

Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>