### PR TITLE
Reduce visibility of class members defined in trans.h

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -171,11 +171,9 @@ int FBCmd::parser(char *p)
 
 int FBCmd::run(CmdCtx *ctx)
 {
-	BulkTrans dev;
+	BulkTrans dev{m_timeout};
 	if (dev.open(ctx->m_dev))
 		return -1;
-
-	dev.m_timeout = m_timeout;
 
 	FastBoot fb(&dev);
 	string cmd;
@@ -191,11 +189,9 @@ int FBCmd::run(CmdCtx *ctx)
 
 int FBPartNumber::run(CmdCtx *ctx)
 {
-	BulkTrans dev;
+	BulkTrans dev{m_timeout};
 	if (dev.open(ctx->m_dev))
 		return -1;
-
-	dev.m_timeout = m_timeout;
 
 	FastBoot fb(&dev);
 
@@ -210,11 +206,9 @@ int FBPartNumber::run(CmdCtx *ctx)
 
 int FBUpdateSuper::run(CmdCtx *ctx)
 {
-	BulkTrans dev;
+	BulkTrans dev{m_timeout};
 	if (dev.open(ctx->m_dev))
 		return -1;
-
-	dev.m_timeout = m_timeout;
 
 	FastBoot fb(&dev);
 
@@ -588,12 +582,11 @@ int FBFlashCmd::run(CmdCtx *ctx)
 
 	size_t max = getvar.m_val.empty() ? m_sparse_limit : str_to_uint32(getvar.m_val);
 
-	BulkTrans dev;
+	BulkTrans dev{m_timeout};
 	if (dev.open(ctx->m_dev))
 		return -1;
 
 	FastBoot fb(&dev);
-	dev.m_timeout = m_timeout;
 
 	if (m_raw2sparse)
 	{

--- a/libuuu/sdp.cpp
+++ b/libuuu/sdp.cpp
@@ -656,8 +656,7 @@ SDPBootlogCmd::SDPBootlogCmd(char *p) : SDPCmdBase(p)
 
 int SDPBootlogCmd::run(CmdCtx *ctx)
 {
-	HIDTrans dev;
-	dev.m_read_timeout = 2000;
+	HIDTrans dev{2000};
 
 	if (dev.open(ctx->m_dev))
 		return -1;

--- a/libuuu/trans.cpp
+++ b/libuuu/trans.cpp
@@ -39,6 +39,8 @@ extern "C"
 #include "libusb.h"
 }
 
+using namespace std;
+
 TransBase::~TransBase()
 {
 }

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -63,9 +63,11 @@ public:
 class USBTrans : public TransBase
 {
 public:
-	vector<EPInfo> m_EPs;
 	int open(void *p) override;
 	int close() override;
+
+protected:
+	vector<EPInfo> m_EPs;
 };
 class HIDTrans : public USBTrans
 {

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -37,7 +37,11 @@
 class TransBase
 {
 public:
+	TransBase() = default;
+	TransBase(const TransBase&) = delete;
+	TransBase& operator=(const TransBase&) = delete;
 	virtual ~TransBase();
+
 	virtual int open(void *) { return 0; }
 	virtual int close() { return 0; }
 	virtual int write(void *buff, size_t size) = 0;

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -39,7 +39,6 @@ using namespace std;
 class TransBase
 {
 public:
-	void * m_devhandle = nullptr;
 	virtual ~TransBase();
 	virtual int open(void *) { return 0; }
 	virtual int close() { return 0; }
@@ -47,6 +46,9 @@ public:
 	virtual int read(void *buff, size_t size, size_t *return_size) = 0;
 	int write(vector<uint8_t> & buff) { return write(buff.data(), buff.size()); }
 	int read(vector<uint8_t> &buff);
+
+protected:
+	void * m_devhandle = nullptr;
 };
 
 class EPInfo

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -71,16 +71,19 @@ protected:
 };
 class HIDTrans : public USBTrans
 {
-	int m_set_report = 9;
-	int m_outEP = 0;
 public:
-	int m_read_timeout = 1000;
-	void set_hid_out_ep(int ep) noexcept { m_outEP = ep; }
+	HIDTrans(int read_timeout = 1000) : m_read_timeout{read_timeout} {}
+	~HIDTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
 
 	int open(void *p) override;
-	~HIDTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
+	void set_hid_out_ep(int ep) noexcept { m_outEP = ep; }
 	int write(void *buff, size_t size) override;
 	int read(void *buff, size_t size, size_t *return_size) override;
+
+private:
+	int m_outEP = 0;
+	const int m_read_timeout = 1000;
+	int m_set_report = 9;
 };
 
 class BulkTrans : public USBTrans

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -89,17 +89,19 @@ private:
 class BulkTrans : public USBTrans
 {
 public:
-	EPInfo m_ep_in;
-	EPInfo m_ep_out;
-	size_t m_MaxTransPreRequest = 0x100000;
-	int m_b_send_zero = 0;
-	uint64_t m_timeout = 2000;
+	BulkTrans(uint64_t timeout = 2000) : m_timeout{timeout} {}
+	~BulkTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
 
 	int open(void *p) override;
-
-	~BulkTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
 	int write(void *buff, size_t size) override;
 	int read(void *buff, size_t size, size_t *return_size) override;
+
+private:
+	size_t m_MaxTransPreRequest = 0x100000;
+	int m_b_send_zero = 0;
+	EPInfo m_ep_in;
+	EPInfo m_ep_out;
+	uint64_t m_timeout = 2000;
 };
 
 int polling_usb(std::atomic<int>& bexit);

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -39,7 +39,6 @@ using namespace std;
 class TransBase
 {
 public:
-	string m_path;
 	void * m_devhandle = nullptr;
 	virtual ~TransBase();
 	virtual int open(void *) { return 0; }

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -34,8 +34,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 class TransBase
 {
 public:
@@ -44,8 +42,8 @@ public:
 	virtual int close() { return 0; }
 	virtual int write(void *buff, size_t size) = 0;
 	virtual int read(void *buff, size_t size, size_t *return_size) = 0;
-	int write(vector<uint8_t> & buff) { return write(buff.data(), buff.size()); }
-	int read(vector<uint8_t> &buff);
+	int write(std::vector<uint8_t> & buff) { return write(buff.data(), buff.size()); }
+	int read(std::vector<uint8_t> &buff);
 
 protected:
 	void * m_devhandle = nullptr;
@@ -67,7 +65,7 @@ public:
 	int close() override;
 
 protected:
-	vector<EPInfo> m_EPs;
+	std::vector<EPInfo> m_EPs;
 };
 class HIDTrans : public USBTrans
 {


### PR DESCRIPTION
This PR is mostly about reducing the visibility of class members of the classes defined in `trans.h`. Additionally the `using namespace std` directive was removed from the header and copying of `TransBase` forbidden.