### PR TITLE
add environment variable support command

### DIFF
--- a/libuuu/cmd.h
+++ b/libuuu/cmd.h
@@ -152,6 +152,18 @@ private:
 	std::string m_shellcmd;
 };
 
+class CmdEnv : public CmdBase
+{
+public:
+	using CmdBase::CmdBase;
+
+	int parser(char *p = nullptr) override;
+	int run(CmdCtx *p) override;
+
+private:
+	std::string m_unfold_cmd;
+};
+
 class CmdList : public std::vector<std::shared_ptr<CmdBase>>
 {
 public:


### PR DESCRIPTION
For example `FBK:@ ucmd echo '@MSG@'`
is equivalent to `FBK:< echo "ucmd echo '$MSG'"` on linux
or `FBK:< echo "ucmd echo '%MSG%'"` on windows.

This allows to write uu files for windows and linux.

Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>