### PR TITLE
Added support for 'FB:reboot' and 'FASTBOOT:reboot'

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -420,6 +420,8 @@ CmdObjCreateMap::CmdObjCreateMap()
 	(*this)["FASTBOOT:FLASH"] = new_cmd_obj<FBFlashCmd>;
 	(*this)["FB:ERASE"] = new_cmd_obj<FBEraseCmd>;
 	(*this)["FASTBOOT:ERASE"] = new_cmd_obj<FBEraseCmd>;
+	(*this)["FB:REBOOT"] = new_cmd_obj<FBRebootCmd>;
+	(*this)["FASTBOOT:REBOOT"] = new_cmd_obj<FBRebootCmd>;
 	(*this)["FB:OEM"] = new_cmd_obj<FBOemCmd>;
 	(*this)["FASTBOOT:OEM"] = new_cmd_obj<FBOemCmd>;
 	(*this)["FB:FLASHING"] = new_cmd_obj<FBFlashingCmd>;

--- a/libuuu/fastboot.h
+++ b/libuuu/fastboot.h
@@ -203,6 +203,14 @@ public:
 	FBEraseCmd(char *p) : FBCmd(p, "erase") {}
 };
 
+
+class FBRebootCmd : public FBCmd
+{
+public:
+	FBRebootCmd(char *p) : FBCmd(p, "reboot") {}
+};
+
+
 class FBSetActiveCmd : public FBCmd
 {
 public:


### PR DESCRIPTION
With this pull request, I propose to add support for the "reboot" fastboot command. For example, at the end of a uuu script, with the proposed change, one can do:

```
FB: reboot 
FB: done
```

or 

```
FASTBOOT: reboot
FASTBOOT: done
```
