### PR TITLE
Macos build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Note that, since uuu is an OSI compliant Open Source project, you are entitled t
 - cmake .
 - make
 
+## macOS
+- git clone https://github.com/NXPmicro/mfgtools.git
+- cd mfgtools
+- brew install libusb libzip pkg-config cmake openssl
+- cmake .
+- make
+
+Note that we assume [brew](https://brew.sh) is installed and can be used to resolve dependencies as shown above. The remaining dependency `libbz2` can be resolved via the X-Code supplied libraries.
+
 # Run environment
  - Windows 10 64 bit
  - Linux (Ubuntu) 64 bit

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Note that we assume [brew](https://brew.sh) is installed and can be used to reso
 # Run environment
  - Windows 10 64 bit
  - Linux (Ubuntu) 64 bit
+ - macOS (Catalina)
  - 32 bit systems will have problems with big files.
 
 # License

--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -13,6 +13,13 @@ if (STATIC)
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 endif()
 
+if (APPLE)
+    # This is a bug in CMake that causes it to prefer the system version over
+    # the one in the specified ROOT folder.
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/Cellar/openssl@1.1/1.1.1g/)
+    set(OPENSSL_CRYPTO_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib CACHE FILEPATH "" FORCE)
+    set(OPENSSL_SSL_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libssl.dylib CACHE FILEPATH "" FORCE)
+endif()
 find_package(OpenSSL)
 
 if(OPENSSL_FOUND)

--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -13,6 +13,13 @@ if (STATIC)
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 endif()
 
+if (APPLE)
+    # This is a bug in CMake that causes it to prefer the system version over
+    # the one in the specified ROOT folder.
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/Cellar/openssl@1.1/1.1.1g/)
+    set(OPENSSL_CRYPTO_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib CACHE FILEPATH "" FORCE)
+    set(OPENSSL_SSL_LIBRARY ${OPENSSL_ROOT_DIR}/lib/libssl.dylib CACHE FILEPATH "" FORCE)
+endif()
 find_package(OpenSSL)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O2 -no-pie")


### PR DESCRIPTION
This modifies the `CMakeList.txt` to make them compatible with macOS using [brew](https://brew.sh) to supply a current version of OpenSSL. The X-Code supplied system library cannot be linked against.