### PR TITLE
fix windows env param read terminates command

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -714,7 +714,7 @@ int CmdEnv::parser(char *p)
 				getenv_s(&len, nullptr, 0, key.c_str());
 				if (!len)
 					return {false, {}};
-				string value(len, '\0');
+				string value(len-1, '\0');
 				getenv_s(&len, &value[0], len, key.c_str());
 				return {true, value};
 #endif


### PR DESCRIPTION
C++ string has the final '\0' of a C string implicit.
This patch fixes the size of created string, so that the string
will contain only one '\0', instead of two.

Signed-off-by: Denis Osterland-Heim <Denis.Osterland@diehl.com>