### PR TITLE
Add macOS build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: c++
 
-git:
-  depth: 300
-  
 matrix:
     include:
-         
+
         - os: osx
           osx_image: xcode9.4
           compiler: clang
@@ -21,16 +18,24 @@ matrix:
         - os: osx
           osx_image: xcode10.1
           compiler: gcc
-          
+
+        - os: osx
+          osx_image: xcode11.6
+          compiler: clang
+
+        - os: osx
+          osx_image: xcode11.6
+          compiler: gcc
+
 addons:
     homebrew:
         update: true
-        brewfile: true
         packages:
+            - cmake
             - libusb
             - libzip
-            - zlib
+            - openssl
+            - pkg-config
 
 script:
-    - export PKG_CONFIG_PATH="/usr/local/opt/zlib/lib/pkgconfig"
-    - cmake . && make
+    - cmake -DOPENSSL_ROOT_DIR=$(brew --cellar)/openssl@1.1/1.1.1g . && make

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Freescale/NXP I.MX Chip image deploy tools.
     1:11     5/5 [                                        ] SDP: jump -f u-boot-dtb.imx -ivtinitramf....
     2:1      1/5 [===>                                    ] SDP: boot -f u-boot-imx7dsabresd_sd.imx ....
 
-# Key features 
+# Key features
  - The real cross platform. Linux, Windows, MacOS(not test yet)
  - Multi devices program support
  - Daemon mode support
@@ -25,21 +25,21 @@ Freescale/NXP I.MX Chip image deploy tools.
 # Examples:
 ```
   uuu u-boot.imx            Download u-boot.imx via HID device
-  
+
   uuu list.uu               Run all the commands in list.uu
-  
-  uuu -s                    Enter shell mode. Input command. 
+
+  uuu -s                    Enter shell mode. Input command.
 
   uuu -v u-boot.imx         verbose mode
- 
-  uuu -d u-boot.imx         Once it detects the attachement of a known device, download boot.imx. 
-                            
+
+  uuu -d u-boot.imx         Once it detects the attachement of a known device, download boot.imx.
+
                             u-boot.imx can be replaced, new file will be download once board reset.
-                            
+
                             Do not unplug the SD card, write to the SD card, nor plug in a SD card when debugging uboot.
-                            
+
   uuu -b emmc u-boot.imx    write u-boot.imx to emmc boot partition. u-boot.imx need enable fastboot
-  
+
   uuu -b emmc_all u-boot.imx sdcard.bz2\*
                             decompress sdcard.bz2 file and download the whole image into emmc
 ```
@@ -49,30 +49,38 @@ Freescale/NXP I.MX Chip image deploy tools.
 The prebuilt image and document are here:
   - https://github.com/NXPmicro/mfgtools/releases
   - UUU.pdf is snapshot of [wiki](https://github.com/NXPmicro/mfgtools/wiki)
- 
+
 # How to Build:
 
 ## Windows
-- git clone https://github.com/NXPmicro/mfgtools.git
-- cd mfgtools
-- git submodule init
-- git submodule update
-- open msvs/uuu.sln with Visual Studio 2017
+- `git clone https://github.com/NXPmicro/mfgtools.git`
+- `cd mfgtools`
+- `git submodule init`
+- `git submodule update`
+- `open msvs/uuu.sln with Visual Studio 2017`
 
 Visual Studio
 
 Note that, since uuu is an OSI compliant Open Source project, you are entitled to download and use the freely available Visual Studio Community Edition to build, run or develop for uuu. As per the Visual Studio Community Edition license this applies regardless of whether you are an individual or a corporate user.
 
 ## Linux
-- git clone https://github.com/NXPmicro/mfgtools.git
-- cd mfgtools
-- sudo apt-get install libusb-1.0-0-dev libzip-dev libbz2-dev pkg-config cmake libssl-dev g++
-- cmake .
-- make
+- `git clone https://github.com/NXPmicro/mfgtools.git`
+- `cd mfgtools`
+- `sudo apt-get install libusb-1.0-0-dev libzip-dev libbz2-dev pkg-config cmake libssl-dev g++`
+- `cmake . && make`
+
+## macOS
+- `git clone https://github.com/NXPmicro/mfgtools.git`
+- `cd mfgtools`
+- `brew install cmake libusb libzip openssl pkg-config`
+- `cmake -DOPENSSL_ROOT_DIR=$(brew --cellar)/openssl@1.1/1.1.1g . && make`
+
+Note that we assume [brew](https://brew.sh) is installed and can be used to resolve dependencies as shown above. The remaining dependency `libbz2` can be resolved via the XCode supplied libraries.
 
 # Run environment
  - Windows 10 64 bit
  - Linux (Ubuntu) 64 bit
+ - macOS (Catalina)
  - 32 bit systems will have problems with big files.
 
 # License


### PR DESCRIPTION
In reference to my original pull requests (see https://github.com/NXPmicro/mfgtools/pull/206 and https://github.com/NXPmicro/mfgtools/pull/217 ) I had another go at improving the macOS build setup.

- No more changes to CMake; use a variable at build time instead
- I added a newer version of macOS to the Travis CI Job and changed some of the existing toolchain in there
  - the git depth of 300 does not appear to actually work according to the Travis [CI documentation](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth): "Travis CI can clone repositories to a maximum depth of 50 commits […]"
  - `brewfile` instructions appear to be unnecessary because this project doesn't use a Brewfile
  - installing `pkg-config` via brew appears to be easier from my perspective compared to exporting a hard coded location
- I updated the readme to use code syntax where actual code is supposed to be executed, e.g. the build instructions, and stripped trailing whitespace
- Flashing something with the uuu tool build with these instructions has actually been tested now, it **works** (when using **Catalina**, as opposed to Mojave https://github.com/NXPmicro/mfgtools/issues/218) 🎉 
  - if there is any kind of proof you require I can check whether this can be organised

Changing the very specific location of the OpenSSL dependency to be less version specific does not appear to be feasible at this time. We could symlink it for Travis via the matrix for macOS specifically but this wouldn't help local builds at all.