### PR TITLE
Reproducible builds and hardening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_SKIP_RPATH ON)
 
 option(BUILD_DOC "Build documentation" OFF)
 

--- a/libuuu/CMakeLists.txt
+++ b/libuuu/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_SKIP_RPATH ON)
 
 find_package(BZip2 REQUIRED)
 find_package(PkgConfig REQUIRED)

--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 find_package(OpenSSL)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O2 -no-pie")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -O2")
 
 if (STATIC)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")

--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.12)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_SKIP_RPATH ON)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUSB REQUIRED libusb-1.0>=1.0.16)
@@ -72,3 +73,4 @@ add_executable(uuu ${SOURCES})
 target_link_libraries(uuu uuc_s ${OPENSSL_LIBRARIES} ${LIBUSB_LIBRARIES} ${LIBZIP_LIBRARIES} ${LIBZ_LIBRARIES} dl bz2)
 
 install(TARGETS uuu DESTINATION bin)
+add_compile_definitions(TARGET_PATH="${CMAKE_INSTALL_PREFIX}/bin/uuu")

--- a/uuu/autocomplete.cpp
+++ b/uuu/autocomplete.cpp
@@ -205,13 +205,10 @@ void print_autocomplete_help()
 #ifndef _MSC_VER
 	{
 		cout << "Enjoy auto [tab] command complete by put below script into /etc/bash_completion.d/uuu" << endl;
-		char result[PATH_MAX];
-		memset(result, 0, PATH_MAX);
-		ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
 		cout << g_vt_kcyn;
 		cout << "  _uuu_autocomplete()" <<endl;
 		cout << "  {" << endl;
-		cout << "       COMPREPLY=($(" << result << " $1 $2 $3))" << endl;
+		cout << "       COMPREPLY=($(" << TARGET_PATH << " $1 $2 $3))" << endl;
 		cout << "  }" << endl;
 		cout << "  complete -o nospace -F _uuu_autocomplete  uuu" << g_vt_default << endl << endl;
 	}


### PR DESCRIPTION
This PR enables two things:

1. Reproducible builds: stop storing build path in the compiled executable since it can vary making the build non reproducible
2. Remove no-pie option: PIE is required for fully enabling Address Space Layout Randomization (ASLR), which makes "Return-oriented" attacks more difficult.

FYI - those patch got tested with an IMX8M Quad and flashing works perfectly.