### PR TITLE
use macOS brewed openssl symbolic link to resolve root dir for cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ addons:
             - pkg-config
 
 script:
-    - cmake -DOPENSSL_ROOT_DIR=$(brew --cellar)/openssl@1.1/1.1.1g . && make
+    - cmake -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl . && make

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note that, since uuu is an OSI compliant Open Source project, you are entitled t
 - `git clone https://github.com/NXPmicro/mfgtools.git`
 - `cd mfgtools`
 - `brew install cmake libusb libzip openssl pkg-config`
-- `cmake -DOPENSSL_ROOT_DIR=$(brew --cellar)/openssl@1.1/1.1.1g . && make`
+- `cmake -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl . && make`
 
 Note that we assume [brew](https://brew.sh) is installed and can be used to resolve dependencies as shown above. The remaining dependency `libbz2` can be resolved via the XCode supplied libraries.
 


### PR DESCRIPTION
By using `$(brew --prefix)/opt/openssl` symbolic link instead of hard
coded Cellar path to fix version, CMake will continue to find OpenSSL
even if the version changes.

Closes #231.