### PR TITLE
Improve compatiblity when running the snap as sudo

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Configure hook to set up configuration when `snap set` is called
+#
+# Copyright (c) 2021 Snapcrafters
+
+# lint: The use of backticks in the printf messages is intended
+# shellcheck disable=SC2016
+
+set \
+    -o errexit \
+    -o errtrace \
+    -o nounset \
+    -o pipefail
+
+disable_snap_confinement_warnings="$(snapctl get disable-snap-confinement-warnings)"
+
+if test -n "${disable_snap_confinement_warnings}"; then
+    if [[ ! "${disable_snap_confinement_warnings}" =~ (false|true) ]]; then
+        printf -- \
+            'Error: disable-snap-confinement-warnings must be either `true` or `false`.\n' \
+            1>&2
+        exit 1
+    fi
+else
+    snapctl set disable-snap-confinement-warnings=false
+fi

--- a/snap/local/launchers/universal-update-utility-launch
+++ b/snap/local/launchers/universal-update-utility-launch
@@ -3,6 +3,9 @@
 # environment changes to make the snap work here.  You may also insert
 # security confinement/deprecation/obsoletion notice of the snap here.
 
+# lint: The use of backticks in the printf messages is intended
+# shellcheck disable=SC2016
+
 set \
     -o errexit \
     -o errtrace \
@@ -11,5 +14,51 @@ set \
 
 #export IMPORTANT_ENVIRONMENT_VARIABLE=value
 
-# Finally run the next part of the command chain
-exec "${@}"
+# Run the command, if fails, check and present security confinement
+# warnings to the user
+if ! "${@}" \
+    && test "$(snapctl get disable-snap-confinement-warnings)" != true; then
+    snap_confinement_warning_triggered=false
+    if ! snapctl is-connected home; then
+        snap_confinement_warning_triggered=true
+        printf \
+            "Warning: It appears that the %s snap isn't connected to the \`home\` interface, accessing files under your home directory will not be possible.\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+        printf \
+            "To fix this problem run the following command as root:\n\n    snap connect %s:home\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+    fi
+
+    if ! snapctl is-connected raw-usb; then
+        snap_confinement_warning_triggered=true
+        printf \
+            "Warning: It appears that the %s snap isn't connected to the \`raw-usb\` interface, direct-access of USB devices will not be possible.\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+        printf \
+            "To fix this problem run the following command as root:\n\n    snap connect %s:raw-usb\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+    fi
+
+    if ! snapctl is-connected removable-media; then
+        snap_confinement_warning_triggered=true
+        printf \
+            "Warning: It appears that the %s snap isn't connected to the \`removable-media\` interface, accessing files under /media and /mnt directory will not be possible.\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+        printf \
+            "To fix this problem run the following command as root:\n\n    snap connect %s:removable-media\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+    fi
+
+    if test "${snap_confinement_warning_triggered}" == true; then
+        printf \
+            "To disable these warnings, run the following command as root:\n\n    snap set %s disable-snap-confinement-warnings=true\n\n" \
+            "${SNAP_NAME}" \
+            1>&2
+    fi
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,6 +132,9 @@ apps:
 plugs:
   # Regular files access
   home:
+    # Allow reading the SUDO_USER's uuu script when run as root
+    # (by default only scripts under root's home dir is readable)
+    read: all
   removable-media: # Non-A/C
 
   # NOTE: This only lifts the snapd side of confinement, the user still

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,8 @@ license: BSD-3-Clause
 adopt-info: main
 assumes:
   - command-chain
+  # required by the `snapctl is-connected` command
+  - snapd2.43
 base: core
 confinement: strict
 grade: stable


### PR DESCRIPTION
This PR adds the `read: all` home interface plug attribute to allow `uuu` to read uuu scripts in the user's home directory when running the snap as root via sudo.  As the home interface becomes non-autoconnect due to this change snap confinement warnings are implemented to notify the user when `uuu` errors due to the confinement.

Then warnings can be opted-out by setting a snap configuration option.