### PR TITLE
Migrate snap base to core18 to mitigate submodule clone error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ assumes:
   - command-chain
   # required by the `snapctl is-connected` command
   - snapd2.43
-base: core
+base: core18
 confinement: strict
 grade: stable
 
@@ -97,7 +97,7 @@ parts:
     build-snaps:
       - cmake
     build-packages:
-      # CMake shipped in Ubuntu 16.04(3.5.1) is too old
+      # CMake shipped in Ubuntu 18.04(3.10.2) is too old
       #- cmake
       - g++
       - libbz2-dev


### PR DESCRIPTION
Ubuntu 16.04 ships a Git distribution that may have trouble cloning
specific submodules.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>