### PR TITLE
Temporary disable snap home interface attribute to avoid manual review

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,7 +142,9 @@ plugs:
   home:
     # Allow reading the SUDO_USER's uuu script when run as root
     # (by default only scripts under root's home dir is readable)
-    read: all
+    # FIXME: Wait for Snap Store approval
+    # https://forum.snapcraft.io/t/interface-auto-connect-request-for-the-universal-update-utility-snap-home-read-all/23125
+    #read: all
   removable-media: # Non-A/C
 
   # NOTE: This only lifts the snapd side of confinement, the user still


### PR DESCRIPTION
In commit 1b9a4d1 we introduced the `read: all` attribute to the `home` interface plug in order to support the run-with-sudo use case, however it triggered a manual review which means that the attribute usage should be vetted by the store reviewers before actually using it.

This patch disables the attribute so that subsequent builds won't be blocked, it should be reverted after the usage is vetted and approved by the Snap Store.

Refer [Process for aliases, auto-connections and tracks - store-requests - snapcraft.io](https://forum.snapcraft.io/t/process-for-aliases-auto-connections-and-tracks/455) for the vetting process.  I've already initiated one at [Interface auto-connect request for the universal-update-utility snap (home; read: all) - store-requests - snapcraft.io](https://forum.snapcraft.io/t/interface-auto-connect-request-for-the-universal-update-utility-snap-home-read-all/23125).