### PR TITLE
Revert "Disable snap home interface attribute to avoid manual review"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,9 +142,7 @@ plugs:
   home:
     # Allow reading the SUDO_USER's uuu script when run as root
     # (by default only scripts under root's home dir is readable)
-    # FIXME: Wait for Snap Store approval
-    # https://forum.snapcraft.io/t/interface-auto-connect-request-for-the-universal-update-utility-snap-home-read-all/23125
-    #read: all
+    read: all
   removable-media: # Non-A/C
 
   # NOTE: This only lifts the snapd side of confinement, the user still


### PR DESCRIPTION
The store review for the new `home` interface use is granted.  Re-introduce
the change so that uuu scripts in the user's home directory can be read by
UUU.

This reverts commit 91f728116139301eb7b17c1b02015731262a9138.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>