### PR TITLE
add timeout for stage change (wait for next device)

### DIFF
--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -128,9 +128,9 @@ int uuu_wait_uuu_finish(int deamon, int dry);
 int uuu_add_usbpath_filter(const char *path);
 
 /*Set timeout wait for known devices appeared*/
-int uuu_set_wait_timeout(int second);
+int uuu_set_wait_timeout(int timeout_in_seconds);
 /*Set usb device polling period */
-void uuu_set_poll_period(int msecond);
+void uuu_set_poll_period(int period_in_milliseconds);
 /*
  * bit 0:15 for libusb
  * bit 16:31 for uuu

--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -129,6 +129,8 @@ int uuu_add_usbpath_filter(const char *path);
 
 /*Set timeout wait for known devices appeared*/
 int uuu_set_wait_timeout(int timeout_in_seconds);
+/*Set timeout wait for next devices appeared, e.g. FB -> FBK*/
+int uuu_set_wait_next_timeout(int timeout_in_seconds);
 /*Set usb device polling period */
 void uuu_set_poll_period(int period_in_milliseconds);
 /*

--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -45,8 +45,6 @@
 #include "vector"
 #include <time.h>
 
-static vector<thread> g_running_thread;
-
 static vector<string> g_filter_usbpath;
 
 static int g_wait_usb_timeout = -1;

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -136,6 +136,7 @@ void print_help(bool detail = false)
 		"    -m          USBPATH Only monitor these paths.\n"
 		"                    -m 1:2 -m 1:3\n\n"
 		"    -t          Timeout second for wait known usb device appeared\n"
+		"    -T          Timeout second for wait next known usb device appeared at stage switch\n"
 		"    -e          set environment variable key=value\n"
 		"    -pp         usb polling period in milliseconds\n"
 		"uuu -s          Enter shell mode. uuu.inputlog record all input commands\n"
@@ -886,6 +887,11 @@ int main(int argc, char **argv)
 			{
 				i++;
 				uuu_set_wait_timeout(atoll(argv[i]));
+			}
+			else if (s == "-T")
+			{
+				i++;
+				uuu_set_wait_next_timeout(atoll(argv[i]));
 			}
 			else if (s == "-pp")
 			{


### PR DESCRIPTION
Hi @nxpfrankli ,

The uuu tool navigates the device through different stages where the device has different USB PID/VID.
Currently the time-out `-t seconds` is only a time-out to find a compatible device at start of tool.
If one device was found, there is no time-out when this device is done and uuu expects that the device comes up with a different ID, again.
This Patches introduce `-T seconds` as a time-out for this situation.
It is implemented as a separate time-out, because the boot of Linux takes time.
You may use this for example with `uuu -t 1 -T 30 my-script.uu` to look 1 second for a compatible device and wait 30 seconds for Linux.

Additionally this merge request comes with some improvements.

Regards, Denis