### PR TITLE
Refactor buildincmds

### DIFF
--- a/uuu/autocomplete.cpp
+++ b/uuu/autocomplete.cpp
@@ -54,6 +54,8 @@
 #include <Windows.h>
 #endif
 
+using namespace std;
+
 void linux_auto_arg(const char *space = " ", const char * filter = "")
 {
 	string str = filter;

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -31,6 +31,13 @@
 
 #include "buildincmd.h"
 
+/**
+ * @brief Parse characters between argument name and its description and check
+ * if its an optional one
+ * @param[in] option The characters between argument name and its description to
+ * be parsed
+ * @return `0` in any case
+ */
 int Arg::parser(std::string option)
 {
 	size_t pos;
@@ -42,6 +49,12 @@ int Arg::parser(std::string option)
 	return 0;
 }
 
+/**
+ * @brief Create a new BuildInScript instance by extracting information from a
+ * BuildCmd instance
+ * @param[in] p The BuildCmd containing all data of the script this
+ * BuildInScript instance shall represent
+ */
 BuildInScript::BuildInScript(BuildCmd*p)
 {
 	m_script = p->m_buildcmd;
@@ -102,6 +115,13 @@ BuildInScript::BuildInScript(BuildCmd*p)
 	}
 }
 
+/**
+ * @brief Check if the BuildInScript instance has an argument called `arg`
+ * @param[in] arg The argument for which its existence in the BuildInScript
+ * shall be checked
+ * @return `true` if BuildInScript has an argument named `arg`, `false`
+ * otherwise
+ */
 bool BuildInScript::find_args(std::string arg)
 {
 	for (size_t i = 0; i < m_args.size(); i++)
@@ -112,6 +132,13 @@ bool BuildInScript::find_args(std::string arg)
 	return false;
 }
 
+/**
+ * @brief Replace built-in script's arguments by actual values given in `args`
+ * @param[in] args The actual values that shall replace the arguments (the order
+ * must fit the order of the arguments in the script)
+ * @return A copy of the built-in script with the arguments replaced by their
+ * actual values
+ */
 std::string BuildInScript::replace_script_args(std::vector<std::string> args)
 {
 	std::string script = m_script;
@@ -138,6 +165,14 @@ std::string BuildInScript::replace_script_args(std::vector<std::string> args)
 	return script;
 }
 
+/**
+ * @brief Replace a `key` substring of a string `str` by a replacement `replace`
+ * @param[in] str The string of which a copy with the replacements shall be
+ * created
+ * @param[in] key The string which shall be replaced
+ * @param[in] replace The string that shall replace ocurrences of `key`
+ * @return
+ */
 std::string BuildInScript::replace_str(std::string str, std::string key, std::string replace)
 {
 	if (replace.size() > 4)
@@ -156,11 +191,17 @@ std::string BuildInScript::replace_str(std::string str, std::string key, std::st
 	return str;
 }
 
+/**
+ * @brief Print the built-in script to `stdout` followed by a newline
+ */
 void BuildInScript::show()
 {
 	printf("%s\n", m_script.c_str());
 }
 
+/**
+ * @brief Print the script's name, its description and its arguments to stdout
+ */
 void BuildInScript::show_cmd()
 {
 	printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_cmd.c_str(), g_vt_default,  m_desc.c_str());
@@ -180,6 +221,12 @@ void BuildInScript::show_cmd()
 	}
 }
 
+/**
+ * @brief Returns a copy of `str` with all applicable characters converted to
+ * uppercase
+ * @param[in] str The string for which an uppercase copy shall be created
+ * @return The copy of `str` converted to uppercase
+ */
 std::string BuildInScript::str_to_upper(std::string str)
 {
 	std::locale loc;
@@ -191,6 +238,10 @@ std::string BuildInScript::str_to_upper(std::string str)
 	return s;
 }
 
+/**
+ * @brief Create a new map by parsing an array of BuildCmd instances
+ * @param[in] p Pointer to the first element of a BuildCmd array
+ */
 BuildInScriptVector::BuildInScriptVector(BuildCmd*p)
 {
 	while (p->m_cmd)
@@ -201,6 +252,12 @@ BuildInScriptVector::BuildInScriptVector(BuildCmd*p)
 	}
 }
 
+/**
+ * @brief Auto-complete names of built-in scripts if they match `match`
+ * @param[in] match The string against which the scripts' names will be machted
+ * @param[in] space A separator character which shall be printed after the
+ * completed script name
+ */
 void BuildInScriptVector::PrintAutoComplete(std::string match, const char *space)
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
@@ -210,6 +267,9 @@ void BuildInScriptVector::PrintAutoComplete(std::string match, const char *space
 	}
 }
 
+/**
+ * @brief Print information about all contained scripts to stdout
+ */
 void BuildInScriptVector::ShowAll()
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
@@ -218,6 +278,10 @@ void BuildInScriptVector::ShowAll()
 	}
 }
 
+/**
+ * @brief Print the names of all contained scripts to the given stream
+ * @param[in] file The stream to which the names shall be printed
+ */
 void BuildInScriptVector::ShowCmds(FILE * file)
 {
 	fprintf(file, "<");
@@ -233,6 +297,7 @@ void BuildInScriptVector::ShowCmds(FILE * file)
 	fprintf(file, ">");
 }
 
+//! Array containing raw information about all the built-in scripts of uuu
 BuildCmd g_buildin_cmd[] =
 {
 	{
@@ -282,4 +347,5 @@ BuildCmd g_buildin_cmd[] =
 	}
 };
 
+//! A map of the built-in scripts' names to their BuildInScript representations
 BuildInScriptVector g_BuildScripts(g_buildin_cmd);

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -31,6 +31,9 @@
 
 #include "buildincmd.h"
 
+static std::string replace_str(std::string str, std::string key, std::string replace);
+static std::string str_to_upper(const std::string &str);
+
 /**
  * @brief Parse characters between argument name and its description and check
  * if its an optional one
@@ -160,32 +163,6 @@ std::string BuiltInScript::replace_script_args(const std::vector<std::string> &a
 }
 
 /**
- * @brief Replace a `key` substring of a string `str` by a replacement `replace`
- * @param[in] str The string of which a copy with the replacements shall be
- * created
- * @param[in] key The string which shall be replaced
- * @param[in] replace The string that shall replace ocurrences of `key`
- * @return
- */
-std::string BuiltInScript::replace_str(std::string str, std::string key, std::string replace) const
-{
-	if (replace.size() > 4)
-	{
-		if (str_to_upper(replace.substr(replace.size() - 4)) == ".BZ2")
-		{
-			replace += "/*";
-		}
-	}
-
-	for (size_t j = 0; (j = str.find(key, j)) != std::string::npos;)
-	{
-		str.replace(j, key.size(), replace);
-		j += key.size();
-	}
-	return str;
-}
-
-/**
  * @brief Print the built-in script to `stdout` followed by a newline
  */
 void BuiltInScript::show() const
@@ -213,23 +190,6 @@ void BuiltInScript::show_cmd() const
 		desc += m_args[i].m_desc;
 		printf("\t\targ%d: %s\n", (int)i, desc.c_str());
 	}
-}
-
-/**
- * @brief Returns a copy of `str` with all applicable characters converted to
- * uppercase
- * @param[in] str The string for which an uppercase copy shall be created
- * @return The copy of `str` converted to uppercase
- */
-std::string BuiltInScript::str_to_upper(const std::string &str) const
-{
-	std::locale loc;
-	std::string s;
-
-	for (size_t i = 0; i < str.size(); i++)
-		s.push_back(std::toupper(str[i], loc));
-
-	return s;
 }
 
 /**
@@ -289,6 +249,52 @@ void BuiltInScriptMap::ShowCmds(FILE * file) const
 			fprintf(file, "|");
 	}
 	fprintf(file, ">");
+}
+
+/**
+ * @brief Replace a `key` substring of a string `str` by a replacement `replace`
+ * @param[in] str The string of which a copy with the replacements shall be
+ * created
+ * @param[in] key The string which shall be replaced
+ * @param[in] replace The string that shall replace ocurrences of `key`
+ * @return A new string instance with the replacements conducted on it
+ */
+static std::string replace_str(std::string str, std::string key, std::string replace)
+{
+	if (replace.size() > 4)
+	{
+		if (str_to_upper(replace.substr(replace.size() - 4)) == ".BZ2")
+		{
+			replace += "/*";
+		}
+	}
+
+	for (size_t j = 0; (j = str.find(key, j)) != std::string::npos;)
+	{
+		str.replace(j, key.size(), replace);
+		j += key.size();
+	}
+	return str;
+}
+
+/**
+ * @brief Returns a copy of `str` with all applicable characters converted to
+ * uppercase
+ * @param[in] str The string for which an uppercase copy shall be created
+ * @return The copy of `str` converted to uppercase
+ */
+static std::string str_to_upper(const std::string &str)
+{
+	std::locale loc;
+	std::string s;
+	s.reserve(str.size());
+
+	for (size_t i = 0; i < str.size(); i++)
+	{
+		s.push_back(std::toupper(str[i], loc));
+	}
+
+	return s;
 }
 
 //! Array containing raw information about all the built-in scripts of uuu

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018 NXP.
+* Copyright 2018-2021 NXP.
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -31,6 +31,208 @@
 
 #include "buildincmd.h"
 
+int Arg::parser(std::string option)
+{
+	size_t pos;
+	pos = option.find('[');
+	if (pos == std::string::npos)
+		return 0;
+	m_options = option.substr(pos + 1, option.find(']') - pos - 1);
+	m_flags = ARG_OPTION | ARG_OPTION_KEY;
+	return 0;
+}
+
+BuildInScript::BuildInScript(BuildCmd*p)
+{
+	m_script = p->m_buildcmd;
+	if(p->m_desc)
+		m_desc = p->m_desc;
+	if(p->m_cmd)
+		m_cmd = p->m_cmd;
+
+	for (size_t i = 1; i < m_script.size(); i++)
+	{
+		size_t off;
+		size_t off_tab;
+		std::string param;
+		if (m_script[i] == '_'
+			&& (m_script[i - 1] == '@' || m_script[i - 1] == ' '))
+		{
+			off = m_script.find(' ', i);
+			off_tab = m_script.find('\t', i);
+			size_t ofn = m_script.find('\n', i);
+			if (off_tab < off)
+				off = off_tab;
+			if (ofn < off)
+				off = ofn;
+
+			if (off == std::string::npos)
+				off = m_script.size() + 1;
+
+			param = m_script.substr(i, off - i);
+			if (!find_args(param))
+			{
+				Arg a;
+				a.m_arg = param;
+				a.m_flags = Arg::ARG_MUST;
+				m_args.push_back(a);
+			}
+		}
+	}
+
+	for (size_t i = 0; i < m_args.size(); i++)
+	{
+		size_t pos = 0;
+		std::string str;
+		str += "@";
+		str += m_args[i].m_arg;
+		pos = m_script.find(str);
+		if (pos != std::string::npos) {
+			std::string def;
+			size_t start_descript;
+			start_descript = m_script.find('|', pos);
+			if (start_descript != std::string::npos)
+			{
+				m_args[i].m_desc = m_script.substr(start_descript + 1,
+										m_script.find('\n', start_descript) - start_descript - 1);
+				def = m_script.substr(pos, start_descript - pos);
+				m_args[i].parser(def);
+			}
+		}
+	}
+}
+
+bool BuildInScript::find_args(std::string arg)
+{
+	for (size_t i = 0; i < m_args.size(); i++)
+	{
+		if (m_args[i].m_arg == arg)
+			return true;
+	}
+	return false;
+}
+
+std::string BuildInScript::replace_script_args(std::vector<std::string> args)
+{
+	std::string script = m_script;
+	for (size_t i = 0; i < args.size() && i < m_args.size(); i++)
+	{
+		script = replace_str(script, m_args[i].m_arg, args[i]);
+	}
+
+	//handle option args;
+	for (size_t i = args.size(); i < m_args.size(); i++)
+	{
+		if (m_args[i].m_flags & Arg::ARG_OPTION_KEY)
+		{
+			for (size_t j = 0; j < args.size(); j++)
+			{
+				if (m_args[j].m_arg == m_args[i].m_options)
+				{
+					script = replace_str(script, m_args[i].m_arg, args[j]);
+					break;
+				}
+			}
+		}
+	}
+	return script;
+}
+
+std::string BuildInScript::replace_str(std::string str, std::string key, std::string replace)
+{
+	if (replace.size() > 4)
+	{
+		if (str_to_upper(replace.substr(replace.size() - 4)) == ".BZ2")
+		{
+			replace += "/*";
+		}
+	}
+
+	for (size_t j = 0; (j = str.find(key, j)) != std::string::npos;)
+	{
+		str.replace(j, key.size(), replace);
+		j += key.size();
+	}
+	return str;
+}
+
+void BuildInScript::show()
+{
+	printf("%s\n", m_script.c_str());
+}
+
+void BuildInScript::show_cmd()
+{
+	printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_cmd.c_str(), g_vt_default,  m_desc.c_str());
+	for (size_t i=0; i < m_args.size(); i++)
+	{
+		std::string desc;
+		desc += m_args[i].m_arg;
+		if (m_args[i].m_flags & Arg::ARG_OPTION)
+		{
+			desc += g_vt_boldwhite;
+			desc += "[Optional]";
+			desc += g_vt_default;
+		}
+		desc += " ";
+		desc += m_args[i].m_desc;
+		printf("\t\targ%d: %s\n", (int)i, desc.c_str());
+	}
+}
+
+std::string BuildInScript::str_to_upper(std::string str)
+{
+	std::locale loc;
+	std::string s;
+
+	for (size_t i = 0; i < str.size(); i++)
+		s.push_back(std::toupper(str[i], loc));
+
+	return s;
+}
+
+BuildInScriptVector::BuildInScriptVector(BuildCmd*p)
+{
+	while (p->m_cmd)
+	{
+		BuildInScript one(p);
+		(*this)[one.m_cmd] = one;
+		p++;
+	}
+}
+
+void BuildInScriptVector::PrintAutoComplete(std::string match, const char *space)
+{
+	for (auto iCol = begin(); iCol != end(); ++iCol)
+			{
+		if(iCol->first.substr(0, match.size()) == match)
+			printf("%s%s\n", iCol->first.c_str(), space);
+	}
+}
+
+void BuildInScriptVector::ShowAll()
+{
+	for (auto iCol = begin(); iCol != end(); ++iCol)
+	{
+		iCol->second.show_cmd();
+	}
+}
+
+void BuildInScriptVector::ShowCmds(FILE * file)
+{
+	fprintf(file, "<");
+	for (auto iCol = begin(); iCol != end(); ++iCol)
+	{
+		fprintf(file, "%s", iCol->first.c_str());
+
+		auto i = iCol;
+		i++;
+		if(i != end())
+			fprintf(file, "|");
+	}
+	fprintf(file, ">");
+}
+
 BuildCmd g_buildin_cmd[] =
 {
 	{

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -186,8 +186,7 @@ BuiltInScriptMap::BuiltInScriptMap(const BuiltInScriptRawData*p)
 {
 	while (p->m_name)
 	{
-		BuiltInScript one(p);
-		(*this)[one.m_name] = one;
+		emplace(p->m_name, p);
 		++p;
 	}
 }

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -38,7 +38,7 @@
  * be parsed
  * @return `0` in any case
  */
-int Arg::parser(std::string option)
+int BuiltInScript::Arg::parser(std::string option)
 {
 	size_t pos;
 	pos = option.find('[');
@@ -50,12 +50,12 @@ int Arg::parser(std::string option)
 }
 
 /**
- * @brief Create a new BuildInScript instance by extracting information from a
- * BuildCmd instance
- * @param[in] p The BuildCmd containing all data of the script this
- * BuildInScript instance shall represent
+ * @brief Create a new BuiltInScript instance by extracting information from a
+ * BuiltInScriptRawData instance
+ * @param[in] p The BuiltInScriptRawData containing all data of the script this
+ * BuiltInScript instance shall represent
  */
-BuildInScript::BuildInScript(BuildCmd*p)
+BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
 {
 	m_script = p->m_buildcmd;
 	if(p->m_desc)
@@ -116,13 +116,13 @@ BuildInScript::BuildInScript(BuildCmd*p)
 }
 
 /**
- * @brief Check if the BuildInScript instance has an argument called `arg`
- * @param[in] arg The argument for which its existence in the BuildInScript
+ * @brief Check if the BuiltInScript instance has an argument called `arg`
+ * @param[in] arg The argument for which its existence in the BuiltInScript
  * shall be checked
- * @return `true` if BuildInScript has an argument named `arg`, `false`
+ * @return `true` if BuiltInScript has an argument named `arg`, `false`
  * otherwise
  */
-bool BuildInScript::find_args(std::string arg)
+bool BuiltInScript::find_args(std::string arg)
 {
 	for (size_t i = 0; i < m_args.size(); i++)
 	{
@@ -139,7 +139,7 @@ bool BuildInScript::find_args(std::string arg)
  * @return A copy of the built-in script with the arguments replaced by their
  * actual values
  */
-std::string BuildInScript::replace_script_args(std::vector<std::string> args)
+std::string BuiltInScript::replace_script_args(std::vector<std::string> args)
 {
 	std::string script = m_script;
 	for (size_t i = 0; i < args.size() && i < m_args.size(); i++)
@@ -173,7 +173,7 @@ std::string BuildInScript::replace_script_args(std::vector<std::string> args)
  * @param[in] replace The string that shall replace ocurrences of `key`
  * @return
  */
-std::string BuildInScript::replace_str(std::string str, std::string key, std::string replace)
+std::string BuiltInScript::replace_str(std::string str, std::string key, std::string replace)
 {
 	if (replace.size() > 4)
 	{
@@ -194,7 +194,7 @@ std::string BuildInScript::replace_str(std::string str, std::string key, std::st
 /**
  * @brief Print the built-in script to `stdout` followed by a newline
  */
-void BuildInScript::show()
+void BuiltInScript::show()
 {
 	printf("%s\n", m_script.c_str());
 }
@@ -202,7 +202,7 @@ void BuildInScript::show()
 /**
  * @brief Print the script's name, its description and its arguments to stdout
  */
-void BuildInScript::show_cmd()
+void BuiltInScript::show_cmd()
 {
 	printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_cmd.c_str(), g_vt_default,  m_desc.c_str());
 	for (size_t i=0; i < m_args.size(); i++)
@@ -227,7 +227,7 @@ void BuildInScript::show_cmd()
  * @param[in] str The string for which an uppercase copy shall be created
  * @return The copy of `str` converted to uppercase
  */
-std::string BuildInScript::str_to_upper(std::string str)
+std::string BuiltInScript::str_to_upper(std::string str)
 {
 	std::locale loc;
 	std::string s;
@@ -239,14 +239,14 @@ std::string BuildInScript::str_to_upper(std::string str)
 }
 
 /**
- * @brief Create a new map by parsing an array of BuildCmd instances
- * @param[in] p Pointer to the first element of a BuildCmd array
+ * @brief Create a new map by parsing an array of BuiltInScriptRawData instances
+ * @param[in] p Pointer to the first element of a BuiltInScriptRawData array
  */
-BuildInScriptVector::BuildInScriptVector(BuildCmd*p)
+BuiltInScriptMap::BuiltInScriptMap(BuiltInScriptRawData*p)
 {
 	while (p->m_cmd)
 	{
-		BuildInScript one(p);
+		BuiltInScript one(p);
 		(*this)[one.m_cmd] = one;
 		p++;
 	}
@@ -258,7 +258,7 @@ BuildInScriptVector::BuildInScriptVector(BuildCmd*p)
  * @param[in] space A separator character which shall be printed after the
  * completed script name
  */
-void BuildInScriptVector::PrintAutoComplete(std::string match, const char *space)
+void BuiltInScriptMap::PrintAutoComplete(std::string match, const char *space)
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
 			{
@@ -270,7 +270,7 @@ void BuildInScriptVector::PrintAutoComplete(std::string match, const char *space
 /**
  * @brief Print information about all contained scripts to stdout
  */
-void BuildInScriptVector::ShowAll()
+void BuiltInScriptMap::ShowAll()
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
 	{
@@ -282,7 +282,7 @@ void BuildInScriptVector::ShowAll()
  * @brief Print the names of all contained scripts to the given stream
  * @param[in] file The stream to which the names shall be printed
  */
-void BuildInScriptVector::ShowCmds(FILE * file)
+void BuiltInScriptMap::ShowCmds(FILE * file)
 {
 	fprintf(file, "<");
 	for (auto iCol = begin(); iCol != end(); ++iCol)
@@ -298,7 +298,7 @@ void BuildInScriptVector::ShowCmds(FILE * file)
 }
 
 //! Array containing raw information about all the built-in scripts of uuu
-BuildCmd g_buildin_cmd[] =
+BuiltInScriptRawData g_builtin_cmd[] =
 {
 	{
 		"emmc",
@@ -347,5 +347,5 @@ BuildCmd g_buildin_cmd[] =
 	}
 };
 
-//! A map of the built-in scripts' names to their BuildInScript representations
-BuildInScriptVector g_BuildScripts(g_buildin_cmd);
+//! A map of the built-in scripts' names to their BuiltInScript representations
+BuiltInScriptMap g_BuildScripts(g_builtin_cmd);

--- a/uuu/buildincmd.cpp
+++ b/uuu/buildincmd.cpp
@@ -38,10 +38,9 @@
  * be parsed
  * @return `0` in any case
  */
-int BuiltInScript::Arg::parser(std::string option)
+int BuiltInScript::Arg::parser(const std::string &option)
 {
-	size_t pos;
-	pos = option.find('[');
+	const auto pos = option.find('[');
 	if (pos == std::string::npos)
 		return 0;
 	m_fallback_option = option.substr(pos + 1, option.find(']') - pos - 1);
@@ -55,7 +54,7 @@ int BuiltInScript::Arg::parser(std::string option)
  * @param[in] p The BuiltInScriptRawData containing all data of the script this
  * BuiltInScript instance shall represent
  */
-BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
+BuiltInScript::BuiltInScript(const BuiltInScriptRawData * const p)
 {
 	m_text = p->m_text;
 	if(p->m_desc)
@@ -66,13 +65,11 @@ BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
 	for (size_t i = 1; i < m_text.size(); i++)
 	{
 		size_t off;
-		size_t off_tab;
-		std::string param;
 		if (m_text[i] == '_'
 			&& (m_text[i - 1] == '@' || m_text[i - 1] == ' '))
 		{
 			off = m_text.find(' ', i);
-			off_tab = m_text.find('\t', i);
+			const auto off_tab = m_text.find('\t', i);
 			size_t ofn = m_text.find('\n', i);
 			if (off_tab < off)
 				off = off_tab;
@@ -82,7 +79,7 @@ BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
 			if (off == std::string::npos)
 				off = m_text.size() + 1;
 
-			param = m_text.substr(i, off - i);
+			const std::string param{m_text.substr(i, off - i)};
 			if (!find_args(param))
 			{
 				Arg a;
@@ -95,20 +92,17 @@ BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
 
 	for (size_t i = 0; i < m_args.size(); i++)
 	{
-		size_t pos = 0;
 		std::string str;
 		str += "@";
 		str += m_args[i].m_name;
-		pos = m_text.find(str);
+		const auto pos = m_text.find(str);
 		if (pos != std::string::npos) {
-			std::string def;
-			size_t start_descript;
-			start_descript = m_text.find('|', pos);
+			const auto start_descript = m_text.find('|', pos);
 			if (start_descript != std::string::npos)
 			{
 				m_args[i].m_desc = m_text.substr(start_descript + 1,
 										m_text.find('\n', start_descript) - start_descript - 1);
-				def = m_text.substr(pos, start_descript - pos);
+				const std::string def{m_text.substr(pos, start_descript - pos)};
 				m_args[i].parser(def);
 			}
 		}
@@ -122,7 +116,7 @@ BuiltInScript::BuiltInScript(BuiltInScriptRawData*p)
  * @return `true` if BuiltInScript has an argument named `arg`, `false`
  * otherwise
  */
-bool BuiltInScript::find_args(std::string arg)
+bool BuiltInScript::find_args(const std::string &arg) const
 {
 	for (size_t i = 0; i < m_args.size(); i++)
 	{
@@ -139,7 +133,7 @@ bool BuiltInScript::find_args(std::string arg)
  * @return A copy of the built-in script with the arguments replaced by their
  * actual values
  */
-std::string BuiltInScript::replace_script_args(std::vector<std::string> args)
+std::string BuiltInScript::replace_script_args(const std::vector<std::string> &args) const
 {
 	std::string script = m_text;
 	for (size_t i = 0; i < args.size() && i < m_args.size(); i++)
@@ -173,7 +167,7 @@ std::string BuiltInScript::replace_script_args(std::vector<std::string> args)
  * @param[in] replace The string that shall replace ocurrences of `key`
  * @return
  */
-std::string BuiltInScript::replace_str(std::string str, std::string key, std::string replace)
+std::string BuiltInScript::replace_str(std::string str, std::string key, std::string replace) const
 {
 	if (replace.size() > 4)
 	{
@@ -194,7 +188,7 @@ std::string BuiltInScript::replace_str(std::string str, std::string key, std::st
 /**
  * @brief Print the built-in script to `stdout` followed by a newline
  */
-void BuiltInScript::show()
+void BuiltInScript::show() const
 {
 	printf("%s\n", m_text.c_str());
 }
@@ -202,7 +196,7 @@ void BuiltInScript::show()
 /**
  * @brief Print the script's name, its description and its arguments to stdout
  */
-void BuiltInScript::show_cmd()
+void BuiltInScript::show_cmd() const
 {
 	printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_name.c_str(), g_vt_default,  m_desc.c_str());
 	for (size_t i=0; i < m_args.size(); i++)
@@ -227,7 +221,7 @@ void BuiltInScript::show_cmd()
  * @param[in] str The string for which an uppercase copy shall be created
  * @return The copy of `str` converted to uppercase
  */
-std::string BuiltInScript::str_to_upper(std::string str)
+std::string BuiltInScript::str_to_upper(const std::string &str) const
 {
 	std::locale loc;
 	std::string s;
@@ -242,7 +236,7 @@ std::string BuiltInScript::str_to_upper(std::string str)
  * @brief Create a new map by parsing an array of BuiltInScriptRawData instances
  * @param[in] p Pointer to the first element of a BuiltInScriptRawData array
  */
-BuiltInScriptMap::BuiltInScriptMap(BuiltInScriptRawData*p)
+BuiltInScriptMap::BuiltInScriptMap(const BuiltInScriptRawData*p)
 {
 	while (p->m_name)
 	{
@@ -258,7 +252,7 @@ BuiltInScriptMap::BuiltInScriptMap(BuiltInScriptRawData*p)
  * @param[in] space A separator character which shall be printed after the
  * completed script name
  */
-void BuiltInScriptMap::PrintAutoComplete(std::string match, const char *space)
+void BuiltInScriptMap::PrintAutoComplete(std::string match, const char *space) const
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
 			{
@@ -270,7 +264,7 @@ void BuiltInScriptMap::PrintAutoComplete(std::string match, const char *space)
 /**
  * @brief Print information about all contained scripts to stdout
  */
-void BuiltInScriptMap::ShowAll()
+void BuiltInScriptMap::ShowAll() const
 {
 	for (auto iCol = begin(); iCol != end(); ++iCol)
 	{
@@ -282,7 +276,7 @@ void BuiltInScriptMap::ShowAll()
  * @brief Print the names of all contained scripts to the given stream
  * @param[in] file The stream to which the names shall be printed
  */
-void BuiltInScriptMap::ShowCmds(FILE * file)
+void BuiltInScriptMap::ShowCmds(FILE * file) const
 {
 	fprintf(file, "<");
 	for (auto iCol = begin(); iCol != end(); ++iCol)
@@ -298,7 +292,7 @@ void BuiltInScriptMap::ShowCmds(FILE * file)
 }
 
 //! Array containing raw information about all the built-in scripts of uuu
-BuiltInScriptRawData g_builtin_cmd[] =
+static constexpr BuiltInScriptRawData g_builtin_cmd[] =
 {
 	{
 		"emmc",

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -63,16 +63,7 @@ public:
 		ARG_OPTION_KEY = 0x4,
 	};
 	Arg() {	m_flags = ARG_MUST;	}
-	int parser(std::string option)
-	{
-		size_t pos;
-		pos = option.find('[');
-		if (pos == std::string::npos)
-			return 0;
-		m_options = option.substr(pos + 1, option.find(']') - pos - 1);
-		m_flags = ARG_OPTION | ARG_OPTION_KEY;
-		return 0;
-	}
+	int parser(std::string option);
 };
 
 class BuildInScript
@@ -82,201 +73,25 @@ public:
 	std::string m_desc;
 	std::string m_cmd;
 	std::vector<Arg> m_args;
-	bool find_args(std::string arg)
-	{
-		for (size_t i = 0; i < m_args.size(); i++)
-		{
-			if (m_args[i].m_arg == arg)
-				return true;
-		}
-		return false;
-	}
+	bool find_args(std::string arg);
 	BuildInScript() {};
-	BuildInScript(BuildCmd*p)
-	{
-		m_script = p->m_buildcmd;
-		if(p->m_desc)
-			m_desc = p->m_desc;
-		if(p->m_cmd)
-			m_cmd = p->m_cmd;
+	BuildInScript(BuildCmd*p);
 
-		for (size_t i = 1; i < m_script.size(); i++)
-		{
-			size_t off;
-			size_t off_tab;
-			std::string param;
-			if (m_script[i] == '_' 
-				&& (m_script[i - 1] == '@' || m_script[i - 1] == ' '))
-			{
-				off = m_script.find(' ', i);
-				off_tab = m_script.find('\t', i);
-				size_t ofn = m_script.find('\n', i);
-				if (off_tab < off)
-					off = off_tab;
-				if (ofn < off)
-					off = ofn;
-
-				if (off == std::string::npos)
-					off = m_script.size() + 1;
-
-				param = m_script.substr(i, off - i);
-				if (!find_args(param))
-				{
-					Arg a;
-					a.m_arg = param;
-					a.m_flags = Arg::ARG_MUST;
-					m_args.push_back(a);
-				}
-			}
-		}
-
-		for (size_t i = 0; i < m_args.size(); i++)
-		{
-			size_t pos = 0;
-			std::string str;
-			str += "@";
-			str += m_args[i].m_arg;
-			pos = m_script.find(str);
-			if (pos != std::string::npos) {
-				std::string def;
-				size_t start_descript;
-				start_descript = m_script.find('|', pos);
-				if (start_descript != std::string::npos)
-				{
-					m_args[i].m_desc = m_script.substr(start_descript + 1,
-											m_script.find('\n', start_descript) - start_descript - 1);
-					def = m_script.substr(pos, start_descript - pos);
-					m_args[i].parser(def);
-				}
-			}
-		}
-	}
-
-	void show()
-	{
-		printf("%s\n", m_script.c_str());
-	}
-
-	void show_cmd()
-	{
-		printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_cmd.c_str(), g_vt_default,  m_desc.c_str());
-		for (size_t i=0; i < m_args.size(); i++)
-		{
-			std::string desc;
-			desc += m_args[i].m_arg;
-			if (m_args[i].m_flags & Arg::ARG_OPTION)
-			{
-				desc += g_vt_boldwhite;
-				desc += "[Optional]";
-				desc += g_vt_default;
-			}
-			desc += " ";
-			desc += m_args[i].m_desc;
-			printf("\t\targ%d: %s\n", (int)i, desc.c_str());
-		}
-	}
-
-	inline std::string str_to_upper(std::string str)
-	{
-		std::locale loc;
-		std::string s;
-
-		for (size_t i = 0; i < str.size(); i++)
-			s.push_back(std::toupper(str[i], loc));
-
-		return s;
-	}
-
-	std::string replace_str(std::string str, std::string key, std::string replace)
-	{
-		if (replace.size() > 4)
-		{
-			if (str_to_upper(replace.substr(replace.size() - 4)) == ".BZ2")
-			{
-				replace += "/*";
-			}
-		}
-
-		for (size_t j = 0; (j = str.find(key, j)) != std::string::npos;)
-		{
-			str.replace(j, key.size(), replace);
-			j += key.size();
-		}
-		return str;
-	}
-
-	std::string replace_script_args(std::vector<std::string> args)
-	{
-		std::string script = m_script;
-		for (size_t i = 0; i < args.size() && i < m_args.size(); i++)
-		{
-			script = replace_str(script, m_args[i].m_arg, args[i]);
-		}
-
-		//handle option args;
-		for (size_t i = args.size(); i < m_args.size(); i++)
-		{
-			if (m_args[i].m_flags & Arg::ARG_OPTION_KEY)
-			{
-				for (size_t j = 0; j < args.size(); j++)
-				{
-					if (m_args[j].m_arg == m_args[i].m_options)
-					{
-						script = replace_str(script, m_args[i].m_arg, args[j]);
-						break;
-					}
-				}
-			}
-		}
-		return script;
-	}
+	void show();
+	void show_cmd();
+	std::string str_to_upper(std::string str);
+	std::string replace_str(std::string str, std::string key, std::string replace);
+	std::string replace_script_args(std::vector<std::string> args);
 };
 
 class BuildInScriptVector : public std::map<std::string, BuildInScript>
 {
 public:
-	BuildInScriptVector(BuildCmd*p)
-	{
-		while (p->m_cmd)
-		{
-			BuildInScript one(p);
-			(*this)[one.m_cmd] = one;
-			p++;
-		}
-	}
+	BuildInScriptVector(BuildCmd*p);
 
-	void ShowAll()
-	{
-		for (auto iCol = begin(); iCol != end(); ++iCol)
-		{
-			iCol->second.show_cmd();
-		}
-	}
-
-	void ShowCmds(FILE * file=stdout)
-	{
-		fprintf(file, "<");
-		for (auto iCol = begin(); iCol != end(); ++iCol)
-		{
-			fprintf(file, "%s", iCol->first.c_str());
-
-			auto i = iCol;
-			i++;
-			if(i != end())
-				fprintf(file, "|");
-		}
-		fprintf(file, ">");
-	}
-
-	void PrintAutoComplete(std::string match, const char *space=" " )
-	{
-		for (auto iCol = begin(); iCol != end(); ++iCol)
-                {
-			if(iCol->first.substr(0, match.size()) == match)
-				printf("%s%s\n", iCol->first.c_str(), space);
-		}
-	}
-
+	void ShowAll();
+	void ShowCmds(FILE * file=stdout);
+	void PrintAutoComplete(std::string match, const char *space=" " );
 };
 
 extern BuildInScriptVector g_BuildScripts;

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -44,38 +44,9 @@ extern const char * g_vt_red ;
 extern const char * g_vt_yellow;
 
 /**
- * @brief A class for representing arguments of built-in scripts represented by
- * BuildCmd
- */
-class Arg
-{
-public:
-	enum
-	{
-		ARG_MUST = 0x1,
-		ARG_OPTION = 0x2,
-		ARG_OPTION_KEY = 0x4,
-	};
-
-	Arg() {	m_flags = ARG_MUST;	}
-
-	int parser(std::string option);
-
-	//! The name of the argument
-	std::string m_arg;
-	//! A description of the argument
-	std::string m_desc;
-	//! Flags of the argument (basically if it's optional or not)
-	uint32_t m_flags;
-	//! The argument whose value this one will fall back to if it's optional and
-	//! not given explicitly
-	std::string m_options;
-};
-
-/**
  * @brief Structure to hold the raw data of a built-in script
  */
-struct BuildCmd
+struct BuiltInScriptRawData
 {
 	//! The name of the built-in script
 	const char *m_cmd;
@@ -85,11 +56,40 @@ struct BuildCmd
 	const char *m_desc;
 };
 
-class BuildInScript
+class BuiltInScript
 {
 public:
-	BuildInScript() {};
-	BuildInScript(BuildCmd*p);
+	/**
+	 * @brief A class for representing arguments of built-in scripts represented
+	 * by BuiltInScript
+	 */
+	class Arg
+	{
+	public:
+		enum
+		{
+			ARG_MUST = 0x1,
+			ARG_OPTION = 0x2,
+			ARG_OPTION_KEY = 0x4,
+		};
+
+		Arg() {	m_flags = ARG_MUST;	}
+
+		int parser(std::string option);
+
+		//! The name of the argument
+		std::string m_arg;
+		//! A description of the argument
+		std::string m_desc;
+		//! Flags of the argument (basically if it's optional or not)
+		uint32_t m_flags;
+		//! The argument whose value this one will fall back to if it's optional
+		//! and not given explicitly
+		std::string m_options;
+	};
+
+	BuiltInScript() {};
+	BuiltInScript(BuiltInScriptRawData*p);
 
 	bool find_args(std::string arg);
 	std::string replace_script_args(std::vector<std::string> args);
@@ -111,17 +111,17 @@ public:
 /**
  * @brief A map of all built-in scripts indexed by their names
  *
- * Each built-in script is represented by a BuildInScript instance.
+ * Each built-in script is represented by a BuiltInScript instance.
  */
-class BuildInScriptVector : public std::map<std::string, BuildInScript>
+class BuiltInScriptMap : public std::map<std::string, BuiltInScript>
 {
 public:
-	BuildInScriptVector(BuildCmd*p);
+	BuiltInScriptMap(BuiltInScriptRawData*p);
 
 	void PrintAutoComplete(std::string match, const char *space=" " );
 	void ShowAll();
 	void ShowCmds(FILE * file=stdout);
 };
 
-//! A map of the built-in scripts' names to their BuildInScript representations
-extern BuildInScriptVector g_BuildScripts;
+//! A map of the built-in scripts' names to their BuiltInScript representations
+extern BuiltInScriptMap g_BuildScripts;

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018 NXP.
+* Copyright 2018-2021 NXP.
 *
 * Redistribution and use in source and binary forms, with or without modification,
 * are permitted provided that the following conditions are met:
@@ -28,19 +28,40 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 */
+
 #pragma once
 
+#include <locale>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
-#include <locale>
 
-extern const char * g_vt_yellow ;
-extern const char * g_vt_default ;
-extern const char * g_vt_green ;
-extern const char * g_vt_red  ;
-extern const char * g_vt_kcyn ;
-extern const char * g_vt_boldwhite ;
+extern const char * g_vt_boldwhite;
+extern const char * g_vt_default;
+extern const char * g_vt_kcyn;
+extern const char * g_vt_green;
+extern const char * g_vt_red ;
+extern const char * g_vt_yellow;
+
+class Arg
+{
+public:
+	enum
+	{
+		ARG_MUST = 0x1,
+		ARG_OPTION = 0x2,
+		ARG_OPTION_KEY = 0x4,
+	};
+
+	Arg() {	m_flags = ARG_MUST;	}
+
+	int parser(std::string option);
+
+	std::string m_arg;
+	std::string m_desc;
+	uint32_t m_flags;
+	std::string m_options;
+};
 
 struct BuildCmd
 {
@@ -49,39 +70,23 @@ struct BuildCmd
 	const char *m_desc;
 };
 
-class Arg
-{
-public:
-	std::string m_arg;
-	std::string m_desc;
-	uint32_t m_flags;
-	std::string m_options;
-	enum
-	{
-		ARG_MUST = 0x1,
-		ARG_OPTION = 0x2,
-		ARG_OPTION_KEY = 0x4,
-	};
-	Arg() {	m_flags = ARG_MUST;	}
-	int parser(std::string option);
-};
-
 class BuildInScript
 {
 public:
+	BuildInScript() {};
+	BuildInScript(BuildCmd*p);
+
+	bool find_args(std::string arg);
+	std::string replace_script_args(std::vector<std::string> args);
+	std::string replace_str(std::string str, std::string key, std::string replace);
+	void show();
+	void show_cmd();
+	std::string str_to_upper(std::string str);
+
 	std::string m_script;
 	std::string m_desc;
 	std::string m_cmd;
 	std::vector<Arg> m_args;
-	bool find_args(std::string arg);
-	BuildInScript() {};
-	BuildInScript(BuildCmd*p);
-
-	void show();
-	void show_cmd();
-	std::string str_to_upper(std::string str);
-	std::string replace_str(std::string str, std::string key, std::string replace);
-	std::string replace_script_args(std::vector<std::string> args);
 };
 
 class BuildInScriptVector : public std::map<std::string, BuildInScript>
@@ -89,9 +94,9 @@ class BuildInScriptVector : public std::map<std::string, BuildInScript>
 public:
 	BuildInScriptVector(BuildCmd*p);
 
+	void PrintAutoComplete(std::string match, const char *space=" " );
 	void ShowAll();
 	void ShowCmds(FILE * file=stdout);
-	void PrintAutoComplete(std::string match, const char *space=" " );
 };
 
 extern BuildInScriptVector g_BuildScripts;

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -91,12 +91,9 @@ public:
 	BuiltInScript() {};
 	BuiltInScript(const BuiltInScriptRawData*p);
 
-	bool find_args(const std::string &arg) const;
 	std::string replace_script_args(const std::vector<std::string> &args) const;
-	std::string replace_str(std::string str, std::string key, std::string replace) const;
 	void show() const;
 	void show_cmd() const;
-	std::string str_to_upper(const std::string &str) const;
 
 	//! The actual script which is being represented
 	std::string m_text;
@@ -106,6 +103,9 @@ public:
 	std::string m_name;
 	//! The arguments of the built-in script
 	std::vector<Arg> m_args;
+
+private:
+	bool find_args(const std::string &arg) const;
 };
 
 /**

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -49,11 +49,11 @@ extern const char * g_vt_yellow;
 struct BuiltInScriptRawData
 {
 	//! The name of the built-in script
-	const char *m_cmd;
+	const char *m_name = nullptr;
 	//! The actual built-in script itself
-	const char *m_buildcmd;
+	const char *m_text = nullptr;
 	//! A description of the built-in script's purpose
-	const char *m_desc;
+	const char *m_desc = nullptr;
 };
 
 class BuiltInScript
@@ -78,14 +78,14 @@ public:
 		int parser(std::string option);
 
 		//! The name of the argument
-		std::string m_arg;
+		std::string m_name;
 		//! A description of the argument
 		std::string m_desc;
 		//! Flags of the argument (basically if it's optional or not)
 		uint32_t m_flags;
 		//! The argument whose value this one will fall back to if it's optional
 		//! and not given explicitly
-		std::string m_options;
+		std::string m_fallback_option;
 	};
 
 	BuiltInScript() {};
@@ -99,11 +99,11 @@ public:
 	std::string str_to_upper(std::string str);
 
 	//! The actual script which is being represented
-	std::string m_script;
+	std::string m_text;
 	//! A description of the script's purpose
 	std::string m_desc;
 	//! A short name of the built-in script
-	std::string m_cmd;
+	std::string m_name;
 	//! The arguments of the built-in script
 	std::vector<Arg> m_args;
 };

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -31,7 +31,6 @@
 
 #pragma once
 
-#include <locale>
 #include <map>
 #include <string>
 #include <vector>
@@ -73,16 +72,14 @@ public:
 			ARG_OPTION_KEY = 0x4,
 		};
 
-		Arg() {	m_flags = ARG_MUST;	}
-
-		int parser(const std::string &option);
+		void parser(const std::string &option);
 
 		//! The name of the argument
 		std::string m_name;
 		//! A description of the argument
 		std::string m_desc;
 		//! Flags of the argument (basically if it's optional or not)
-		uint32_t m_flags;
+		uint32_t m_flags = ARG_MUST;
 		//! The argument whose value this one will fall back to if it's optional
 		//! and not given explicitly
 		std::string m_fallback_option;
@@ -118,7 +115,7 @@ class BuiltInScriptMap : public std::map<std::string, BuiltInScript>
 public:
 	BuiltInScriptMap(const BuiltInScriptRawData*p);
 
-	void PrintAutoComplete(std::string match, const char *space=" " ) const;
+	void PrintAutoComplete(const std::string &match, const char *space = " ") const;
 	void ShowAll() const;
 	void ShowCmds(FILE * file=stdout) const;
 };

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -48,11 +48,11 @@ extern const char * g_vt_yellow;
 struct BuiltInScriptRawData
 {
 	//! The name of the built-in script
-	const char *m_name = nullptr;
+	const char * const m_name = nullptr;
 	//! The actual built-in script itself
-	const char *m_text = nullptr;
+	const char * const m_text = nullptr;
 	//! A description of the built-in script's purpose
-	const char *m_desc = nullptr;
+	const char * const m_desc = nullptr;
 };
 
 class BuiltInScript
@@ -93,11 +93,11 @@ public:
 	void show_cmd() const;
 
 	//! The actual script which is being represented
-	std::string m_text;
+	const std::string m_text;
 	//! A description of the script's purpose
-	std::string m_desc;
+	const std::string m_desc;
 	//! A short name of the built-in script
-	std::string m_name;
+	const std::string m_name;
 	//! The arguments of the built-in script
 	std::vector<Arg> m_args;
 

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -75,7 +75,7 @@ public:
 
 		Arg() {	m_flags = ARG_MUST;	}
 
-		int parser(std::string option);
+		int parser(const std::string &option);
 
 		//! The name of the argument
 		std::string m_name;
@@ -89,14 +89,14 @@ public:
 	};
 
 	BuiltInScript() {};
-	BuiltInScript(BuiltInScriptRawData*p);
+	BuiltInScript(const BuiltInScriptRawData*p);
 
-	bool find_args(std::string arg);
-	std::string replace_script_args(std::vector<std::string> args);
-	std::string replace_str(std::string str, std::string key, std::string replace);
-	void show();
-	void show_cmd();
-	std::string str_to_upper(std::string str);
+	bool find_args(const std::string &arg) const;
+	std::string replace_script_args(const std::vector<std::string> &args) const;
+	std::string replace_str(std::string str, std::string key, std::string replace) const;
+	void show() const;
+	void show_cmd() const;
+	std::string str_to_upper(const std::string &str) const;
 
 	//! The actual script which is being represented
 	std::string m_text;
@@ -116,11 +116,11 @@ public:
 class BuiltInScriptMap : public std::map<std::string, BuiltInScript>
 {
 public:
-	BuiltInScriptMap(BuiltInScriptRawData*p);
+	BuiltInScriptMap(const BuiltInScriptRawData*p);
 
-	void PrintAutoComplete(std::string match, const char *space=" " );
-	void ShowAll();
-	void ShowCmds(FILE * file=stdout);
+	void PrintAutoComplete(std::string match, const char *space=" " ) const;
+	void ShowAll() const;
+	void ShowCmds(FILE * file=stdout) const;
 };
 
 //! A map of the built-in scripts' names to their BuiltInScript representations

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -43,6 +43,10 @@ extern const char * g_vt_green;
 extern const char * g_vt_red ;
 extern const char * g_vt_yellow;
 
+/**
+ * @brief A class for representing arguments of built-in scripts represented by
+ * BuildCmd
+ */
 class Arg
 {
 public:
@@ -57,16 +61,27 @@ public:
 
 	int parser(std::string option);
 
+	//! The name of the argument
 	std::string m_arg;
+	//! A description of the argument
 	std::string m_desc;
+	//! Flags of the argument (basically if it's optional or not)
 	uint32_t m_flags;
+	//! The argument whose value this one will fall back to if it's optional and
+	//! not given explicitly
 	std::string m_options;
 };
 
+/**
+ * @brief Structure to hold the raw data of a built-in script
+ */
 struct BuildCmd
 {
+	//! The name of the built-in script
 	const char *m_cmd;
+	//! The actual built-in script itself
 	const char *m_buildcmd;
+	//! A description of the built-in script's purpose
 	const char *m_desc;
 };
 
@@ -83,12 +98,21 @@ public:
 	void show_cmd();
 	std::string str_to_upper(std::string str);
 
+	//! The actual script which is being represented
 	std::string m_script;
+	//! A description of the script's purpose
 	std::string m_desc;
+	//! A short name of the built-in script
 	std::string m_cmd;
+	//! The arguments of the built-in script
 	std::vector<Arg> m_args;
 };
 
+/**
+ * @brief A map of all built-in scripts indexed by their names
+ *
+ * Each built-in script is represented by a BuildInScript instance.
+ */
 class BuildInScriptVector : public std::map<std::string, BuildInScript>
 {
 public:
@@ -99,4 +123,5 @@ public:
 	void ShowCmds(FILE * file=stdout);
 };
 
+//! A map of the built-in scripts' names to their BuildInScript representations
 extern BuildInScriptVector g_BuildScripts;

--- a/uuu/buildincmd.h
+++ b/uuu/buildincmd.h
@@ -35,8 +35,6 @@
 #include <map>
 #include <locale>
 
-using namespace std;
-
 extern const char * g_vt_yellow ;
 extern const char * g_vt_default ;
 extern const char * g_vt_green ;
@@ -54,10 +52,10 @@ struct BuildCmd
 class Arg
 {
 public:
-	string m_arg;
-	string m_desc;
+	std::string m_arg;
+	std::string m_desc;
 	uint32_t m_flags;
-	string m_options;
+	std::string m_options;
 	enum
 	{
 		ARG_MUST = 0x1,
@@ -65,11 +63,11 @@ public:
 		ARG_OPTION_KEY = 0x4,
 	};
 	Arg() {	m_flags = ARG_MUST;	}
-	int parser(string option)
+	int parser(std::string option)
 	{
 		size_t pos;
 		pos = option.find('[');
-		if (pos == string::npos)
+		if (pos == std::string::npos)
 			return 0;
 		m_options = option.substr(pos + 1, option.find(']') - pos - 1);
 		m_flags = ARG_OPTION | ARG_OPTION_KEY;
@@ -80,11 +78,11 @@ public:
 class BuildInScript
 {
 public:
-	string m_script;
-	string m_desc;
-	string m_cmd;
-	vector<Arg> m_args;
-	bool find_args(string arg)
+	std::string m_script;
+	std::string m_desc;
+	std::string m_cmd;
+	std::vector<Arg> m_args;
+	bool find_args(std::string arg)
 	{
 		for (size_t i = 0; i < m_args.size(); i++)
 		{
@@ -106,7 +104,7 @@ public:
 		{
 			size_t off;
 			size_t off_tab;
-			string param;
+			std::string param;
 			if (m_script[i] == '_' 
 				&& (m_script[i - 1] == '@' || m_script[i - 1] == ' '))
 			{
@@ -118,7 +116,7 @@ public:
 				if (ofn < off)
 					off = ofn;
 
-				if (off == string::npos)
+				if (off == std::string::npos)
 					off = m_script.size() + 1;
 
 				param = m_script.substr(i, off - i);
@@ -135,15 +133,15 @@ public:
 		for (size_t i = 0; i < m_args.size(); i++)
 		{
 			size_t pos = 0;
-			string str;
+			std::string str;
 			str += "@";
 			str += m_args[i].m_arg;
 			pos = m_script.find(str);
-			if (pos != string::npos) {
-				string def;
+			if (pos != std::string::npos) {
+				std::string def;
 				size_t start_descript;
 				start_descript = m_script.find('|', pos);
-				if (start_descript != string::npos)
+				if (start_descript != std::string::npos)
 				{
 					m_args[i].m_desc = m_script.substr(start_descript + 1,
 											m_script.find('\n', start_descript) - start_descript - 1);
@@ -164,7 +162,7 @@ public:
 		printf("\t%s%s%s\t%s\n", g_vt_boldwhite, m_cmd.c_str(), g_vt_default,  m_desc.c_str());
 		for (size_t i=0; i < m_args.size(); i++)
 		{
-			string desc;
+			std::string desc;
 			desc += m_args[i].m_arg;
 			if (m_args[i].m_flags & Arg::ARG_OPTION)
 			{
@@ -178,10 +176,10 @@ public:
 		}
 	}
 
-	inline string str_to_upper(string str)
+	inline std::string str_to_upper(std::string str)
 	{
 		std::locale loc;
-		string s;
+		std::string s;
 
 		for (size_t i = 0; i < str.size(); i++)
 			s.push_back(std::toupper(str[i], loc));
@@ -189,7 +187,7 @@ public:
 		return s;
 	}
 
-	string replace_str(string str, string key, string replace)
+	std::string replace_str(std::string str, std::string key, std::string replace)
 	{
 		if (replace.size() > 4)
 		{
@@ -199,7 +197,7 @@ public:
 			}
 		}
 
-		for (size_t j = 0; (j = str.find(key, j)) != string::npos;)
+		for (size_t j = 0; (j = str.find(key, j)) != std::string::npos;)
 		{
 			str.replace(j, key.size(), replace);
 			j += key.size();
@@ -207,9 +205,9 @@ public:
 		return str;
 	}
 
-	string replace_script_args(vector<string> args)
+	std::string replace_script_args(std::vector<std::string> args)
 	{
-		string script = m_script;
+		std::string script = m_script;
 		for (size_t i = 0; i < args.size() && i < m_args.size(); i++)
 		{
 			script = replace_str(script, m_args[i].m_arg, args[i]);
@@ -234,7 +232,7 @@ public:
 	}
 };
 
-class BuildInScriptVector : public map<string, BuildInScript>
+class BuildInScriptVector : public std::map<std::string, BuildInScript>
 {
 public:
 	BuildInScriptVector(BuildCmd*p)
@@ -270,7 +268,7 @@ public:
 		fprintf(file, ">");
 	}
 
-	void PrintAutoComplete(string match, const char *space=" " )
+	void PrintAutoComplete(std::string match, const char *space=" " )
 	{
 		for (auto iCol = begin(); iCol != end(); ++iCol)
                 {

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -838,7 +838,7 @@ int main(int argc, char **argv)
 			}
 			else
 			{
-				string str = g_BuildScripts[argv[2]].m_script;
+				string str = g_BuildScripts[argv[2]].m_text;
 				while (str.size() > 0 && (str[0] == '\n' || str[0] == ' '))
 					str = str.erase(0,1);
 
@@ -977,7 +977,7 @@ int main(int argc, char **argv)
 				if (g_BuildScripts.find(argv[i + 1]) == g_BuildScripts.end()) {
 					BuiltInScriptRawData tmpCmd;
 					string tmpCmdFileName = argv[i + 1];
-					tmpCmd.m_cmd = tmpCmdFileName.c_str();
+					tmpCmd.m_name = tmpCmdFileName.c_str();
 
 					std::ifstream t(tmpCmdFileName);
 					std::string fileContents((std::istreambuf_iterator<char>(t)),
@@ -988,7 +988,7 @@ int main(int argc, char **argv)
 						return -1;
 					}
 
-					tmpCmd.m_buildcmd = fileContents.c_str();
+					tmpCmd.m_text = fileContents.c_str();
 
 					tmpCmd.m_desc = "Script loaded from file";
 

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -975,9 +975,7 @@ int main(int argc, char **argv)
 
 				// if script name is not build-in, try to look for a file
 				if (g_BuildScripts.find(argv[i + 1]) == g_BuildScripts.end()) {
-					BuiltInScriptRawData tmpCmd;
-					string tmpCmdFileName = argv[i + 1];
-					tmpCmd.m_name = tmpCmdFileName.c_str();
+					const string tmpCmdFileName{argv[i + 1]};
 
 					std::ifstream t(tmpCmdFileName);
 					std::string fileContents((std::istreambuf_iterator<char>(t)),
@@ -988,12 +986,13 @@ int main(int argc, char **argv)
 						return -1;
 					}
 
-					tmpCmd.m_text = fileContents.c_str();
+					BuiltInScriptRawData tmpCmd{
+						tmpCmdFileName.c_str(),
+						fileContents.c_str(),
+						"Script loaded from file"
+					};
 
-					tmpCmd.m_desc = "Script loaded from file";
-
-					BuiltInScript tmpBuiltInScript(&tmpCmd);
-					g_BuildScripts[tmpCmdFileName] = tmpBuiltInScript;
+					g_BuildScripts.emplace(tmpCmdFileName, &tmpCmd);
 
 					cmd_script = g_BuildScripts[tmpCmdFileName].replace_script_args(args);
 				}

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -975,7 +975,7 @@ int main(int argc, char **argv)
 
 				// if script name is not build-in, try to look for a file
 				if (g_BuildScripts.find(argv[i + 1]) == g_BuildScripts.end()) {
-					BuildCmd tmpCmd;
+					BuiltInScriptRawData tmpCmd;
 					string tmpCmdFileName = argv[i + 1];
 					tmpCmd.m_cmd = tmpCmdFileName.c_str();
 
@@ -992,8 +992,8 @@ int main(int argc, char **argv)
 
 					tmpCmd.m_desc = "Script loaded from file";
 
-					BuildInScript tmpBuildInScript(&tmpCmd);
-					g_BuildScripts[tmpCmdFileName] = tmpBuildInScript;
+					BuiltInScript tmpBuiltInScript(&tmpCmd);
+					g_BuildScripts[tmpCmdFileName] = tmpBuiltInScript;
 
 					cmd_script = g_BuildScripts[tmpCmdFileName].replace_script_args(args);
 				}


### PR DESCRIPTION
Hi,

I always had trouble to get my head around the stuff concerning buildcmd. These days this prompted me to give a it a revamp. I tried to improve the maintainability by:

- moving method definitions into the source file
- reordering the classes alphabetically and their members to common practise
- increase documentation coverage
- adjust the names of the classes and their members to better fit their purposes
- reducing visibility and scope of entities
- introducing regular expressions to parse the lines defining arguments

My last (still unresolved) pull request sparked in me the question which C++ standard you are aiming for. Long time ago you let a pull request of mine pass to raise the C++ standard version to C++14. Normally I try my code on Ubuntu 16.04, but somehow the more recent Microsoft and Apple compilers seem to fail on some stuff, so in this pull request I tried to be conservative ;-) Maybe it would be worthwhile to add a short section to the readme, which should be the oldest supported system/compilers. I'd love to drop in some C++17 goodness, but as an embedded developer I understand the value of backwards compatible software (just recently I tried to revive some software with the last commit from 2013).