### PR TITLE
Fix some spelling errors

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -267,7 +267,7 @@ int CmdMap::run_all(const std::string &protocol, CmdCtx *p, bool dry_run)
 	{
 		set_last_err_id(-1);
 		std::string err;
-		err.append("Unknown Protocal:");
+		err.append("Unknown Protocol:");
 		err.append(protocol);
 		set_last_err_string(err);
 		return -1;
@@ -577,7 +577,7 @@ int CmdDelay::parser(char * /*p*/)
 
 	if (str_to_upper(param) != "DELAY")
 	{
-		string err = "Unknown Commnd:";
+		string err = "Unknown Command:";
 		err += param;
 		set_last_err_string(err);
 		return -1;

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -116,7 +116,7 @@ int FBGetVar::parser(char *p)
 
 	if (str_to_upper(param) != "GETVAR")
 	{
-		string err = "Unknown Commnd:";
+		string err = "Unknown Command:";
 		err += param;
 		set_last_err_string(err);
 		return -1;


### PR DESCRIPTION
This is to fix some spelling errors reported by the Debian lintian tool on package build.

