### PR TITLE
Fixed misspelled 'download' command format in FBCopy

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -354,7 +354,7 @@ int FBCopy::run(CmdCtx *ctx)
 			if (sz > m_Maxsize_pre_cmd)
 				sz = m_Maxsize_pre_cmd;
 
-			cmd.format("donwload:%08X", sz);
+			cmd.format("download:%08X", sz);
 			if (fb.Transport(cmd, buff->data() + i, sz))
 			{
 				if (fb.m_info == "EPIPE")


### PR DESCRIPTION
This patch fixes a misspelled 'download' command in the FBCopy run() function.
I noticed this error while perusing the codebase for some other modifications that
are in progress.