### PR TITLE
Add 'upload' fastboot command support

### DIFF
--- a/libuuu/cmd.cpp
+++ b/libuuu/cmd.cpp
@@ -418,6 +418,8 @@ CmdObjCreateMap::CmdObjCreateMap()
 	(*this)["FASTBOOT:ACMD"] = new_cmd_obj<FBACmd>;
 	(*this)["FB:DOWNLOAD"] = new_cmd_obj<FBDownload>;
 	(*this)["FASTBOOT:DOWNLOAD"] = new_cmd_obj<FBDownload>;
+	(*this)["FB:UPLOAD"] = new_cmd_obj<FBUpload>;
+	(*this)["FASTBOOT:UPLOAD"] = new_cmd_obj<FBUpload>;
 	(*this)["FB:FLASH"] = new_cmd_obj<FBFlashCmd>;
 	(*this)["FASTBOOT:FLASH"] = new_cmd_obj<FBFlashCmd>;
 	(*this)["FB:ERASE"] = new_cmd_obj<FBEraseCmd>;

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -242,6 +242,29 @@ int FBDownload::run(CmdCtx *ctx)
 	return 0;
 }
 
+int FBUpload::run(CmdCtx* ctx)
+{
+	BulkTrans dev;
+	if (dev.open( ctx->m_dev ))
+		return -1;
+
+	FastBoot fb(&dev);
+	
+	string_ex cmd;
+	cmd.format("upload");
+
+	std::vector<uint8_t> buff;
+	if (fb.Transport(cmd, nullptr, buff.size(), &buff))
+		return -1;
+
+	std::ofstream fout(m_filename, ios::out | ios::trunc);
+	std::copy(buff.begin(), buff.end(), std::ostream_iterator<uint8_t>( fout ));
+	fout.flush();
+	fout.close();
+
+	return 0;
+}
+
 int FBCopy::parser(char *p)
 {
 	if (p)

--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -245,7 +245,7 @@ int FBDownload::run(CmdCtx *ctx)
 int FBUpload::run(CmdCtx* ctx)
 {
 	BulkTrans dev;
-	if (dev.open( ctx->m_dev ))
+	if (dev.open(ctx->m_dev))
 		return -1;
 
 	FastBoot fb(&dev);
@@ -258,7 +258,7 @@ int FBUpload::run(CmdCtx* ctx)
 		return -1;
 
 	std::ofstream fout(m_filename, ios::out | ios::trunc);
-	std::copy(buff.begin(), buff.end(), std::ostream_iterator<uint8_t>( fout ));
+	std::copy(buff.begin(), buff.end(), std::ostream_iterator<uint8_t>(fout));
 	fout.flush();
 	fout.close();
 

--- a/libuuu/fastboot.h
+++ b/libuuu/fastboot.h
@@ -251,3 +251,18 @@ class FBContinueCmd : public FBCmd
 public:
 	FBContinueCmd(char *p) : FBCmd(p, "continue") {}
 };
+
+class FBUpload : public CmdBase
+{
+public:
+	FBUpload(char* p) : CmdBase(p)
+	{
+		insert_param_info("upload", nullptr, Param::Type::e_null);
+		insert_param_info("-f", &m_filename, Param::Type::e_string);
+	}
+
+	int run(CmdCtx* ctx) override;
+
+private:
+	std::string m_filename;
+};


### PR DESCRIPTION
Some bootloader implementations support the 'upload' command, which allows for data
to be transmitted from UBOOT -> UUU.  This command is necessary when performing advanced
flashing operations, such as configuring the security features on i.MX SoC's.

Example of where this command would be utilized: uploading the 'mppubk' from
UBOOT so attestation keys and certificates can be encrypted before they are pushed
and burned to secure storage in a 'closed chip' configuration.