### PR TITLE
Fix cmake warning related to uuu tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 
+project(uuu)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_SKIP_RPATH ON)


### PR DESCRIPTION
As reported by cmake output, `project(uuu)' must be added to
CMakeLists.txt.

Signed-off-by: Dario Binacchi <dario.binacchi@amarulasolutions.com>