### PR TITLE
Fixed QSPI flashing script

### DIFF
--- a/uuu/qspi_burn_loader.lst
+++ b/uuu/qspi_burn_loader.lst
@@ -29,7 +29,7 @@ SDPV: jump
 FB: ucmd setenv fastboot_buffer ${loadaddr}
 FB: download -f _image
 
-FB: ucmd if test ! -n "$fastboot_bytes"; then setenv fastboot_bytes $filesize; fi
+FB: ucmd if test ! -n "$fastboot_bytes"; then setenv fastboot_bytes $filesize; else true; fi
 
 # Check Image if include flexspi header
 FB: ucmd if qspihdr dump ${fastboot_buffer}; then setenv qspihdr_exist yes; else setenv qspihdr_exist no; fi;


### PR DESCRIPTION
On U-Boot version `2021.04` the ENV variable `fastboot_bytes` is set dynamically after `download` and this causes the script to stop abryptly. Hence added dummy `else` condition to ensure the proper flow.

The following image shows the `fastboot_bytes` set to `filesize` after the download command:
![Screenshot from 2021-12-10 10-58-40](https://user-images.githubusercontent.com/50566479/145522274-9d1ff0eb-b100-4dda-85c4-3fda55763ef1.png)

closes #307 

---

CC @tkmozhi