### PR TITLE
Fixed invalid progress percentage in verbose mode

### DIFF
--- a/libuuu/hidreport.cpp
+++ b/libuuu/hidreport.cpp
@@ -92,6 +92,7 @@ int HIDReport::write(const void *p, size_t sz, uint8_t report_id)
 			notify(off, uuu_notify::NOTIFY_TRANS_POS);
 		}
 	}
-	notify(off, uuu_notify::NOTIFY_TRANS_POS);
+
+	notify(sz, uuu_notify::NOTIFY_TRANS_POS);
 	return 0;
 }


### PR DESCRIPTION
In `HIDReport::write()`, the final `off` value can be greater than `sz`, and this causes uuu to display an invalid percentage value (>100%) in verbose mode. For example:

```
1:1>Start Cmd:SDP: write -f .\firmware\imx6ull-xxx-uuu-64m.dtb -addr 0x83000000
102%1:1>Okay (0.009s)
```

```
1:1>Start Cmd:SDP: jump -f .\firmware\u-boot-mfg_signed.imx -ivt
6400%1:1>Okay (1.002s)
```
I fixed this by limiting the `NOTIFY_TRANS_POS` notify's value to `sz`.