### PR TITLE
Correct libusb usage

### DIFF
--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -66,6 +66,15 @@ enum KnownDeviceState {
 };
 static atomic<KnownDeviceState> g_known_device_state{NoKnownDevice};
 
+class CAutoDeInit
+{
+public:
+	~CAutoDeInit()
+	{
+		libusb_exit(nullptr);
+	}
+} g_autoDeInit;
+
 class CAutoList
 {
 public:


### PR DESCRIPTION
This PR aims to fix problems discussed in #312:

- Also fix problem 1 at `uuu_for_each_devices()` and `polling_usb()`
- Fix problem 2 by using global object destructor