### PR TITLE
Specify 'ios::binary' in ofstream initialization

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -264,7 +264,7 @@ int FBUpload::run(CmdCtx* ctx)
 	if (fb.Transport(cmd, nullptr, buff.size(), &buff))
 		return -1;
 
-	std::ofstream fout(m_filename, ios::out | ios::trunc);
+	std::ofstream fout(m_filename, ios::out | ios::trunc | ios::binary);
 	std::copy(buff.begin(), buff.end(), std::ostream_iterator<uint8_t>(fout));
 	fout.flush();
 	fout.close();


### PR DESCRIPTION
When executed on a Windows platform, any data that contains a line feed character
('\n') will automatically have a carriage return ('\r') added before the line feed, unless
the ofstream is opened with the 'ios::binary' flag.  Adding carriage returns to important
data retrieved from the fastboot buffer (e.g. MPPUBK) is not ideal, as it can interfere with
how that data is used.