### PR TITLE
Skip sleep in usb_add

### DIFF
--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -307,7 +307,6 @@ static int usb_add(libusb_device *dev)
 		return -1;
 
 	ConfigItem *item = get_config()->find(desc.idVendor, desc.idProduct, desc.bcdDevice);
-	this_thread::sleep_for(g_usb_poll_period.load());
 
 	if (item)
 	{


### PR DESCRIPTION
The 200ms sleep in usb_add is run once per attached usb device. On a system with many usb devices, this can result in a wait time of several seconds, even when the device waited for is already connected.

Remove the sleep, since I don't see any adverse effects of doing so.

Signed-off-by: Torleiv Sundre <torleiv@huddly.com>