### PR TITLE
Fastboot: check if `logical-block-size` is successfully converted

### DIFF
--- a/libuuu/fastboot.cpp
+++ b/libuuu/fastboot.cpp
@@ -719,8 +719,15 @@ int FBFlashCmd::run(CmdCtx *ctx)
 			size_t block_size = 4096;
 			if (getvar.parser((char*)"FB: getvar logical-block-size"))
 				return -1;
-			if (!getvar.run(ctx))
-				block_size = str_to_uint32(getvar.m_val);
+
+			if (!getvar.run(ctx)) {
+				bool conversion_succeeded = false;
+				size_t tmp_block_size = str_to_uint32(getvar.m_val, &conversion_succeeded);
+
+				if (conversion_succeeded) {
+					block_size = tmp_block_size;
+				}
+			}
 
 			if (block_size == 0) {
 				set_last_err_string("Device report block_size is 0");


### PR DESCRIPTION
There is a misbehaviour which can be caused by Third Party bootloader that supports Fastboot protocol (for example, Barebox).
The issue appears if the following conditions are met:
- bootloader doesn't report `logical-block-size`
- bootloader sends empty `INFO` if variable doesn't exist (was allowed by old Fastboot protocol: https://android.googlesource.com/platform/system/core/+show/refs/heads/main/fastboot/README.md#127)

So, if we use `uuu` with `raw2sparse` flag to flash an image, the resulting image is corrupted because the used block size is 
set to `UINT32_MAX`.

To prevent such a behaviour, we redefine block size only if a conversion succeeded.