### PR TITLE
libuuu: avoid repeated claims on libusb handles

### DIFF
--- a/libuuu/cmd.h
+++ b/libuuu/cmd.h
@@ -35,6 +35,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "trans.h"
 
 class ConfigItem;
 
@@ -49,7 +50,7 @@ public:
 	virtual ~CmdCtx();
 
 	ConfigItem *m_config_item = nullptr;
-	void *m_dev = nullptr;
+	TransHandle m_dev;
 	short m_current_bcd;
 };
 

--- a/libuuu/trans.cpp
+++ b/libuuu/trans.cpp
@@ -102,31 +102,20 @@ int TransBase::read(vector<uint8_t> &buff)
 	return ret;
 }
 
-int USBTrans::open(void *p)
+int USBTrans::open(TransHandle &usb)
 {
-	m_devhandle = p;
+	if (usb.handle == nullptr) {
+		set_last_err_string("Invalid USB device handle");
+		return -1;
+	}
+
+	m_devhandle = usb.handle;
 	string_ex err;
-	int libusb_ret = 0;
 	libusb_device_handle * handle = (libusb_device_handle *)m_devhandle;
 
-	if (libusb_kernel_driver_active(handle, 0))
-	{
-		libusb_ret = libusb_detach_kernel_driver((libusb_device_handle *)m_devhandle, 0);
-
-		if(libusb_ret < 0 && libusb_ret != LIBUSB_ERROR_NOT_SUPPORTED)
-		{
-			err.format("detach kernel driver failure (%d)", libusb_ret);
-			set_last_err_string(err);
-			return libusb_ret;
-		}
-	}
-
-	if ((libusb_ret = libusb_claim_interface(handle, 0)))
-	{
-		err.format("Failure claim interface (%d)", libusb_ret);
-		set_last_err_string(err);
+	int libusb_ret = ensure_interface_claimed(usb);
+	if (libusb_ret)
 		return libusb_ret;
-	}
 
 	libusb_config_descriptor *config;
 	if ((libusb_ret = libusb_get_active_config_descriptor(libusb_get_device(handle), &config)))
@@ -148,6 +137,47 @@ int USBTrans::open(void *p)
 	return 0;
 }
 
+int USBTrans::ensure_interface_claimed(TransHandle &usb)
+{
+	/*
+	 * A fastboot session keeps one libusb handle open and reuses it across
+	 * multiple commands, even though each command creates a fresh transport.
+	 *
+	 * Record the claimed state in the session handle so detach/claim only
+	 * happens once per session. Repeating that path on the same handle is
+	 * unnecessary and triggers a problem on macOS where the second capture
+	 * of the same interface will fail when not running as root.
+	 */
+	if (usb.interface_claimed)
+		return 0;
+
+	string_ex err;
+	libusb_device_handle *handle = (libusb_device_handle *)usb.handle;
+	int libusb_ret = 0;
+
+	if (libusb_kernel_driver_active(handle, 0))
+	{
+		libusb_ret = libusb_detach_kernel_driver(handle, 0);
+
+		if (libusb_ret < 0 && libusb_ret != LIBUSB_ERROR_NOT_SUPPORTED)
+		{
+			err.format("detach kernel driver failure (%d)", libusb_ret);
+			set_last_err_string(err);
+			return libusb_ret;
+		}
+	}
+
+	if ((libusb_ret = libusb_claim_interface(handle, 0)))
+	{
+		err.format("Failure claim interface (%d)", libusb_ret);
+		set_last_err_string(err);
+		return libusb_ret;
+	}
+
+	usb.interface_claimed = true;
+	return 0;
+}
+
 int USBTrans::close()
 {
 	/* needn't clean resource here
@@ -156,7 +186,7 @@ int USBTrans::close()
 	return 0;
 }
 
-int HIDTrans::open(void *p)
+int HIDTrans::open(TransHandle &p)
 {
 	int ret;
 
@@ -295,7 +325,7 @@ int BulkTrans::write_simple(void *buff, size_t size)
 	return ret;
 }
 
-int BulkTrans::open(void *p)
+int BulkTrans::open(TransHandle &p)
 {
 	int ret;
 

--- a/libuuu/trans.h
+++ b/libuuu/trans.h
@@ -34,6 +34,12 @@
 #include <string>
 #include <vector>
 
+struct TransHandle
+{
+	void *handle = nullptr;
+	bool interface_claimed = false;
+};
+
 class TransBase
 {
 public:
@@ -42,7 +48,7 @@ public:
 	TransBase& operator=(const TransBase&) = delete;
 	virtual ~TransBase();
 
-	virtual int open(void *) { return 0; }
+	virtual int open(TransHandle &) { return 0; }
 	virtual int close() { return 0; }
 	int write(void *buff, size_t size);
 	int read(void *buff, size_t size, size_t *return_size);
@@ -70,11 +76,14 @@ class USBTrans : public TransBase
 {
 public:
 	USBTrans(int retry = 1) : TransBase(retry) {}
-	int open(void *p) override;
+	int open(TransHandle &p) override;
 	int close() override;
 
 protected:
 	std::vector<EPInfo> m_EPs;
+
+private:
+	int ensure_interface_claimed(TransHandle &usb);
 };
 class HIDTrans : public USBTrans
 {
@@ -82,7 +91,7 @@ public:
 	HIDTrans(int timeout = 1000) : USBTrans(2), m_timeout{timeout} {}
 	~HIDTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
 
-	int open(void *p) override;
+	int open(TransHandle &p) override;
 	void set_hid_out_ep(int ep) noexcept { m_outEP = ep; }
 
 protected:
@@ -101,7 +110,7 @@ public:
 	BulkTrans(int timeout = 2000) : USBTrans(2), m_timeout{timeout} {}
 	~BulkTrans() override { if (m_devhandle) close();  m_devhandle = nullptr; }
 
-	int open(void *p) override;
+	int open(TransHandle &p) override;
 
 protected:
 	int write_simple(void *buff, size_t size) override;

--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -46,6 +46,7 @@
 #include "cmd.h"
 #include "libcomm.h"
 #include "libuuu.h"
+#include "trans.h"
 #include "rominfo.h"
 #include "vector"
 #include <time.h>
@@ -279,7 +280,7 @@ static string get_device_serial_no(libusb_device *dev)
 	return get_device_serial_no(dev, &desc, item);
 }
 
-static int open_libusb(libusb_device *dev, void **usb_device_handle)
+static int open_libusb(libusb_device *dev, TransHandle *usb_device_handle)
 {
 	int retry = 10;
 
@@ -297,7 +298,8 @@ static int open_libusb(libusb_device *dev, void **usb_device_handle)
 		CAutoList l;
 
 		int ret;
-		if ((ret = libusb_open(dev, (libusb_device_handle **)(usb_device_handle))) < 0)
+		libusb_device_handle *handle = nullptr;
+		if ((ret = libusb_open(dev, &handle)) < 0)
 		{
 			if ((ret != LIBUSB_ERROR_NOT_SUPPORTED && ret != LIBUSB_ERROR_ACCESS)
 			    || (retry == 0))
@@ -309,6 +311,8 @@ static int open_libusb(libusb_device *dev, void **usb_device_handle)
 		}
 		else
 		{
+			usb_device_handle->handle = handle;
+			usb_device_handle->interface_claimed = false;
 			return 0;
 		}
 	}
@@ -343,7 +347,7 @@ static int run_usb_cmds(ConfigItem *item, libusb_device *dev, short bcddevice)
 	ctx.m_config_item = item;
 	ctx.m_current_bcd = bcddevice;
 
-	if ((ret = open_libusb(dev, &(ctx.m_dev))))
+	if ((ret = open_libusb(dev, &ctx.m_dev)))
 	{
 		nt.type = uuu_notify::NOTIFY_CMD_END;
 		nt.status = -1;
@@ -509,10 +513,11 @@ int polling_usb(std::atomic<int>& bexit)
 
 CmdUsbCtx::~CmdUsbCtx()
 {
-	if (m_dev)
+	if (m_dev.handle)
 	{
-		libusb_close((libusb_device_handle*)m_dev);
-		m_dev = 0;
+		libusb_close((libusb_device_handle*)m_dev.handle);
+		m_dev.handle = nullptr;
+		m_dev.interface_claimed = false;
 	}
 }
 
@@ -561,7 +566,7 @@ int CmdUsbCtx::look_for_match_device(const char *pro)
 					m_current_bcd = desc.bcdDevice;
 
 					int ret;
-					if ((ret = open_libusb(dev, &(m_dev))))
+					if ((ret = open_libusb(dev, &m_dev)))
 						return ret;
 
 					nt.str = (char*)str.c_str();


### PR DESCRIPTION
On macOS, fastboot sessions with multiple successive FB: ucmd commands could fail on the second command with a libusb capture error, or, when run under sudo, leave the current USB attachment inaccessible to later non-root libusb clients until the device re-enumerated.

This was observed on Apple Silicon macOS with Darwin 24.1.0.

A minimal repro is:

  1. Start from a fresh fastboot attachment.
  2. Run a script containing one FB: ucmd command: it succeeds.
  3. Run a script containing two successive FB: ucmd commands:
     - as a normal user, the second command fails with a libusb capture error on macOS
     - under sudo, both commands succeed, but later non-root libusb clients can no longer access the current attachment until the device re-enumerates.

The root cause is that libuuu already keeps a single libusb_device_handle open for the lifetime of the protocol thread, but each fastboot command creates a fresh BulkTrans and re-enters USBTrans::open() on that same handle. That path called libusb_kernel_driver_active(), libusb_detach_kernel_driver() and libusb_claim_interface() again for every command, even though the handle had already been claimed.

Make the detach/claim step happen only once per reused libusb_device_handle by storing the open handle and its interface-claimed state together in the command session context. USBTrans::open() now uses that session-owned state to skip repeated detach/claim on later fastboot commands, while endpoint discovery still runs per command so the existing fastboot command flow stays intact.

This seem to fix the strange repeated multi-ucmd failure seen on macOS.