### PR TITLE
Remove unused 'int' variable

### DIFF
--- a/uuu/autocomplete.cpp
+++ b/uuu/autocomplete.cpp
@@ -61,7 +61,6 @@ void linux_auto_arg(const char *space = " ", const char * filter = "")
 	string str = filter;
 
 	const char *param[] = { "-b", "-d", "-v", "-V", "-s", NULL };
-	int i = 0;
 
 	for (int i = 0; param[i]; i++)
 	{


### PR DESCRIPTION
Remove unused int variable to prevent compiler waring and improve code style.

No functional change.