### PR TITLE
Remove unnecessary constructor implementation

### DIFF
--- a/libuuu/http.cpp
+++ b/libuuu/http.cpp
@@ -377,11 +377,6 @@ HttpStream::~HttpStream()
 
 #else
 
-HttpStream::HttpStream()
-{
-	m_buff.empty();
-}
-
 int HttpStream::SendPacket(char *buff, size_t sz)
 {
 #ifdef UUUSSL

--- a/libuuu/http.h
+++ b/libuuu/http.h
@@ -51,7 +51,7 @@ class HttpStream
 	void * m_ssl = nullptr;
 	int parser_response(std::string rep);
 public:
-	HttpStream();
+	HttpStream() = default;
 	int HttpGetHeader(std::string host, std::string path, int port = 80, bool ishttps=false);
 	size_t HttpGetFileSize();
 	int HttpDownload(char *buff, size_t sz);


### PR DESCRIPTION
Remove unnecessary constructor implementation as it contained an unchecked function call, causing a compiler warning. Additionally, mark the constructor in the declaration as default.