### PR TITLE
Remove unnecessary constructor implementation

### DIFF
--- a/libuuu/http.cpp
+++ b/libuuu/http.cpp
@@ -377,10 +377,7 @@ HttpStream::~HttpStream()
 
 #else
 
-HttpStream::HttpStream()
-{
-	m_buff.empty();
-}
+HttpStream::HttpStream() = default;
 
 int HttpStream::SendPacket(char *buff, size_t sz)
 {


### PR DESCRIPTION
Mark constructor implementation as default when compiling on Linux, as the original version contained an unused vector::empty() call, causing compiler warnings.